### PR TITLE
Add Force Backend Proxy option for HLS streams

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -296,6 +296,20 @@
               </div>
             </div>
 
+
+            <div class="settings-section">
+              <h3>Streaming</h3>
+              <div class="setting-item">
+                <label class="setting-toggle">
+                  <input type="checkbox" id="setting-force-proxy">
+                  <span class="toggle-slider"></span>
+                </label>
+                <div class="setting-info">
+                  <span class="setting-label">Force Backend Proxy</span>
+                  <span class="setting-hint">Route all streams through your server (uses more bandwidth but avoids CORS issues)</span>
+                </div>
+              </div>
+            </div>
             <div class="settings-section">
               <h3>Keyboard Shortcuts</h3>
               <div class="shortcuts-grid">

--- a/public/js/pages/Settings.js
+++ b/public/js/pages/Settings.js
@@ -5,8 +5,8 @@
 class SettingsPage {
     constructor(app) {
         this.app = app;
-        this.tabs = document.querySelectorAll('.tabs .tab');
-        this.tabContents = document.querySelectorAll('.tab-content');
+        this.tabs = document.querySelectorAll(".tabs .tab");
+        this.tabContents = document.querySelectorAll(".tab-content");
 
         this.init();
     }
@@ -14,7 +14,7 @@ class SettingsPage {
     init() {
         // Tab switching
         this.tabs.forEach(tab => {
-            tab.addEventListener('click', () => this.switchTab(tab.dataset.tab));
+            tab.addEventListener("click", () => this.switchTab(tab.dataset.tab));
         });
 
         // Player settings
@@ -22,31 +22,35 @@ class SettingsPage {
     }
 
     initPlayerSettings() {
-        const arrowKeysToggle = document.getElementById('setting-arrow-keys');
-        const overlayDurationInput = document.getElementById('setting-overlay-duration');
-        const defaultVolumeSlider = document.getElementById('setting-default-volume');
-        const volumeValueDisplay = document.getElementById('volume-value');
-        const rememberVolumeToggle = document.getElementById('setting-remember-volume');
-        const autoPlayNextToggle = document.getElementById('setting-autoplay-next');
+        const arrowKeysToggle = document.getElementById("setting-arrow-keys");
+        const overlayDurationInput = document.getElementById("setting-overlay-duration");
+        const defaultVolumeSlider = document.getElementById("setting-default-volume");
+        const volumeValueDisplay = document.getElementById("volume-value");
+        const rememberVolumeToggle = document.getElementById("setting-remember-volume");
+        const autoPlayNextToggle = document.getElementById("setting-autoplay-next");
+        const forceProxyToggle = document.getElementById("setting-force-proxy");
 
         // Load current settings
         if (this.app.player?.settings) {
             arrowKeysToggle.checked = this.app.player.settings.arrowKeysChangeChannel;
             overlayDurationInput.value = this.app.player.settings.overlayDuration;
             defaultVolumeSlider.value = this.app.player.settings.defaultVolume;
-            volumeValueDisplay.textContent = this.app.player.settings.defaultVolume + '%';
+            volumeValueDisplay.textContent = this.app.player.settings.defaultVolume + "%";
             rememberVolumeToggle.checked = this.app.player.settings.rememberVolume;
             autoPlayNextToggle.checked = this.app.player.settings.autoPlayNextEpisode;
+            if (forceProxyToggle) {
+                forceProxyToggle.checked = this.app.player.settings.forceProxy || false;
+            }
         }
 
         // Arrow keys toggle
-        arrowKeysToggle.addEventListener('change', () => {
+        arrowKeysToggle.addEventListener("change", () => {
             this.app.player.settings.arrowKeysChangeChannel = arrowKeysToggle.checked;
             this.app.player.saveSettings();
         });
 
         // Overlay duration
-        overlayDurationInput.addEventListener('change', () => {
+        overlayDurationInput.addEventListener("change", () => {
             const value = Math.min(30, Math.max(1, parseInt(overlayDurationInput.value) || 5));
             overlayDurationInput.value = value;
             this.app.player.settings.overlayDuration = value;
@@ -54,47 +58,53 @@ class SettingsPage {
         });
 
         // Default volume slider
-        defaultVolumeSlider?.addEventListener('input', () => {
+        defaultVolumeSlider?.addEventListener("input", () => {
             const value = parseInt(defaultVolumeSlider.value);
-            volumeValueDisplay.textContent = value + '%';
+            volumeValueDisplay.textContent = value + "%";
             this.app.player.settings.defaultVolume = value;
             this.app.player.saveSettings();
         });
 
         // Remember volume toggle
-        rememberVolumeToggle?.addEventListener('change', () => {
+        rememberVolumeToggle?.addEventListener("change", () => {
             this.app.player.settings.rememberVolume = rememberVolumeToggle.checked;
             this.app.player.saveSettings();
         });
 
         // Auto-play next episode toggle
-        autoPlayNextToggle?.addEventListener('change', () => {
+        autoPlayNextToggle?.addEventListener("change", () => {
             this.app.player.settings.autoPlayNextEpisode = autoPlayNextToggle.checked;
             this.app.player.saveSettings();
         });
 
+        // Force proxy toggle
+        forceProxyToggle?.addEventListener("change", () => {
+            this.app.player.settings.forceProxy = forceProxyToggle.checked;
+            this.app.player.saveSettings();
+        });
+
         // EPG refresh interval
-        const epgRefreshSelect = document.getElementById('epg-refresh-interval');
+        const epgRefreshSelect = document.getElementById("epg-refresh-interval");
         if (epgRefreshSelect) {
             // Load saved value
-            const savedInterval = localStorage.getItem('nodecast_tv_epg_refresh_interval');
+            const savedInterval = localStorage.getItem("nodecast_tv_epg_refresh_interval");
             if (savedInterval) {
                 epgRefreshSelect.value = savedInterval;
             }
 
             // Save on change
-            epgRefreshSelect.addEventListener('change', () => {
-                localStorage.setItem('nodecast_tv_epg_refresh_interval', epgRefreshSelect.value);
+            epgRefreshSelect.addEventListener("change", () => {
+                localStorage.setItem("nodecast_tv_epg_refresh_interval", epgRefreshSelect.value);
             });
         }
     }
 
     switchTab(tabName) {
-        this.tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));
-        this.tabContents.forEach(c => c.classList.toggle('active', c.id === `tab-${tabName}`));
+        this.tabs.forEach(t => t.classList.toggle("active", t.dataset.tab === tabName));
+        this.tabContents.forEach(c => c.classList.toggle("active", c.id === `tab-${tabName}`));
 
         // Load content browser when switching to that tab
-        if (tabName === 'content') {
+        if (tabName === "content") {
             this.app.sourceManager.loadContentSources();
         }
     }
@@ -104,11 +114,15 @@ class SettingsPage {
         await this.app.sourceManager.loadSources();
 
         // Refresh player settings display
-        const arrowKeysToggle = document.getElementById('setting-arrow-keys');
-        const overlayDurationInput = document.getElementById('setting-overlay-duration');
+        const arrowKeysToggle = document.getElementById("setting-arrow-keys");
+        const overlayDurationInput = document.getElementById("setting-overlay-duration");
+        const forceProxyToggle = document.getElementById("setting-force-proxy");
         if (this.app.player?.settings) {
             arrowKeysToggle.checked = this.app.player.settings.arrowKeysChangeChannel;
             overlayDurationInput.value = this.app.player.settings.overlayDuration;
+            if (forceProxyToggle) {
+                forceProxyToggle.checked = this.app.player.settings.forceProxy || false;
+            }
         }
     }
 

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -1,352 +1,254 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const { sources } = require('../db');
-const xtreamApi = require('../services/xtreamApi');
-const m3uParser = require('../services/m3uParser');
-const epgParser = require('../services/epgParser');
-const cache = require('../services/cache');
-
-// Default cache TTL: 24 hours
-const DEFAULT_MAX_AGE_HOURS = 24;
+const { sources } = require("../db");
+const xtreamApi = require("../services/xtreamApi");
+const m3uParser = require("../services/m3uParser");
+const epgParser = require("../services/epgParser");
 
 /**
  * Proxy Xtream API calls
- * GET /api/proxy/xtream/:sourceId/:action
  */
-router.get('/xtream/:sourceId/:action', async (req, res) => {
+router.get("/xtream/:sourceId/:action", async (req, res) => {
     try {
-        const sourceId = req.params.sourceId;
-        const source = sources.getById(sourceId);
-        if (!source || source.type !== 'xtream') {
-            return res.status(404).json({ error: 'Xtream source not found' });
+        const source = sources.getById(req.params.sourceId);
+        if (!source || source.type !== "xtream") {
+            return res.status(404).json({ error: "Xtream source not found" });
         }
 
-        const { action } = req.params;
-        const { category_id, stream_id, vod_id, series_id, limit, refresh, maxAge } = req.query;
-        const forceRefresh = refresh === '1';
-        const maxAgeHours = parseInt(maxAge) || DEFAULT_MAX_AGE_HOURS;
-        const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
-
-        // Actions that should be cached
-        const cacheableActions = [
-            'live_categories', 'live_streams',
-            'vod_categories', 'vod_streams',
-            'series_categories', 'series'
-        ];
-
-        // Build cache key (include category_id if present)
-        const cacheKey = category_id ? `${action}_${category_id}` : action;
-
-        // Check cache for cacheable actions
-        if (!forceRefresh && cacheableActions.includes(action)) {
-            const cached = cache.get('xtream', sourceId, cacheKey, maxAgeMs);
-            if (cached) {
-                return res.json(cached);
-            }
-        }
-
-        // Fetch fresh data
         const api = xtreamApi.createFromSource(source);
+        const { action } = req.params;
+        const { category_id, stream_id, vod_id, series_id, limit } = req.query;
+
         let data;
         switch (action) {
-            case 'auth':
-                data = await api.authenticate();
-                break;
-            case 'live_categories':
-                data = await api.getLiveCategories();
-                break;
-            case 'live_streams':
-                data = await api.getLiveStreams(category_id);
-                break;
-            case 'vod_categories':
-                data = await api.getVodCategories();
-                break;
-            case 'vod_streams':
-                data = await api.getVodStreams(category_id);
-                break;
-            case 'vod_info':
-                data = await api.getVodInfo(vod_id);
-                break;
-            case 'series_categories':
-                data = await api.getSeriesCategories();
-                break;
-            case 'series':
-                data = await api.getSeries(category_id);
-                break;
-            case 'series_info':
-                data = await api.getSeriesInfo(series_id);
-                break;
-            case 'short_epg':
-                data = await api.getShortEpg(stream_id, limit);
-                break;
-            default:
-                return res.status(400).json({ error: 'Unknown action' });
+            case "auth": data = await api.authenticate(); break;
+            case "live_categories": data = await api.getLiveCategories(); break;
+            case "live_streams": data = await api.getLiveStreams(category_id); break;
+            case "vod_categories": data = await api.getVodCategories(); break;
+            case "vod_streams": data = await api.getVodStreams(category_id); break;
+            case "vod_info": data = await api.getVodInfo(vod_id); break;
+            case "series_categories": data = await api.getSeriesCategories(); break;
+            case "series": data = await api.getSeries(category_id); break;
+            case "series_info": data = await api.getSeriesInfo(series_id); break;
+            case "short_epg": data = await api.getShortEpg(stream_id, limit); break;
+            default: return res.status(400).json({ error: "Unknown action" });
         }
-
-        // Cache the result for cacheable actions
-        if (cacheableActions.includes(action)) {
-            cache.set('xtream', sourceId, cacheKey, data);
-        }
-
         res.json(data);
     } catch (err) {
-        console.error('Xtream proxy error:', err);
+        console.error("Xtream proxy error:", err);
         res.status(500).json({ error: err.message });
     }
 });
 
-/**
- * Get Xtream stream URL
- * GET /api/proxy/xtream/:sourceId/stream/:streamId
- */
-router.get('/xtream/:sourceId/stream/:streamId/:type?', (req, res) => {
+router.get("/xtream/:sourceId/stream/:streamId/:type?", (req, res) => {
     try {
         const source = sources.getById(req.params.sourceId);
-        if (!source || source.type !== 'xtream') {
-            return res.status(404).json({ error: 'Xtream source not found' });
+        if (!source || source.type !== "xtream") {
+            return res.status(404).json({ error: "Xtream source not found" });
         }
-
         const api = xtreamApi.createFromSource(source);
-        const { streamId, type = 'live' } = req.params;
-        const { container = 'm3u8' } = req.query;
-
+        const { streamId, type = "live" } = req.params;
+        const { container = "m3u8" } = req.query;
         const url = api.buildStreamUrl(streamId, type, container);
         res.json({ url });
     } catch (err) {
-        console.error('Stream URL error:', err);
+        console.error("Stream URL error:", err);
         res.status(500).json({ error: err.message });
     }
 });
 
-/**
- * Fetch and parse M3U playlist
- * GET /api/proxy/m3u/:sourceId
- */
-router.get('/m3u/:sourceId', async (req, res) => {
+router.get("/m3u/:sourceId", async (req, res) => {
     try {
-        const sourceId = req.params.sourceId;
-        const source = sources.getById(sourceId);
-        if (!source || source.type !== 'm3u') {
-            return res.status(404).json({ error: 'M3U source not found' });
+        const source = sources.getById(req.params.sourceId);
+        if (!source || source.type !== "m3u") {
+            return res.status(404).json({ error: "M3U source not found" });
         }
-
-        const forceRefresh = req.query.refresh === '1';
-        const maxAgeHours = parseInt(req.query.maxAge) || DEFAULT_MAX_AGE_HOURS;
-        const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
-
-        // Check cache
-        if (!forceRefresh) {
-            const cached = cache.get('m3u', sourceId, 'playlist', maxAgeMs);
-            if (cached) {
-                return res.json(cached);
-            }
-        }
-
         const data = await m3uParser.fetchAndParse(source.url);
-
-        // Store in cache
-        cache.set('m3u', sourceId, 'playlist', data);
-
         res.json(data);
     } catch (err) {
-        console.error('M3U proxy error:', err);
+        console.error("M3U proxy error:", err);
         res.status(500).json({ error: err.message });
     }
 });
 
-/**
- * Fetch and parse EPG (with file-based caching)
- * GET /api/proxy/epg/:sourceId
- * Query params:
- *   - refresh=1  Force refresh, bypass cache
- *   - maxAge=N   Max cache age in hours (default 24)
- */
-router.get('/epg/:sourceId', async (req, res) => {
+const epgMemoryCache = {};
+
+router.get("/epg/:sourceId", async (req, res) => {
     try {
         const sourceId = req.params.sourceId;
         const source = sources.getById(sourceId);
-        if (!source || (source.type !== 'epg' && source.type !== 'xtream')) {
-            return res.status(404).json({ error: 'Valid EPG source not found' });
+        if (!source || (source.type !== "epg" && source.type !== "xtream")) {
+            return res.status(404).json({ error: "Valid EPG source not found" });
         }
 
-        const forceRefresh = req.query.refresh === '1';
-        const maxAgeHours = parseInt(req.query.maxAge) || DEFAULT_MAX_AGE_HOURS;
+        const forceRefresh = req.query.refresh === "1";
+        const maxAgeHours = parseInt(req.query.maxAge) || 24;
         const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
 
-        // Check file cache (unless force refresh)
-        if (!forceRefresh) {
-            const cached = cache.get('epg', sourceId, 'data', maxAgeMs);
-            if (cached) {
-                return res.json(cached);
+        if (!forceRefresh && epgMemoryCache[sourceId]) {
+            const cached = epgMemoryCache[sourceId];
+            if (Date.now() - cached.fetchedAt < maxAgeMs) {
+                return res.json(cached.data);
             }
         }
 
-        // Fetch fresh data
         let url = source.url;
-        if (source.type === 'xtream') {
+        if (source.type === "xtream") {
             const api = xtreamApi.createFromSource(source);
             url = api.getXmltvUrl();
         }
 
         const data = await epgParser.fetchAndParse(url);
-
-        // Store in file cache
-        cache.set('epg', sourceId, 'data', data);
-
+        epgMemoryCache[sourceId] = { data, fetchedAt: Date.now() };
         res.json(data);
     } catch (err) {
-        console.error('EPG proxy error:', err);
+        console.error("EPG proxy error:", err);
         res.status(500).json({ error: err.message });
     }
 });
 
-/**
- * Clear cache for a source
- * DELETE /api/proxy/cache/:sourceId
- */
-router.delete('/cache/:sourceId', (req, res) => {
-    const sourceId = req.params.sourceId;
-    cache.clearSource(sourceId);
+router.delete("/epg/:sourceId/cache", (req, res) => {
+    delete epgMemoryCache[req.params.sourceId];
     res.json({ success: true });
 });
 
-/**
- * Clear EPG cache for a source (legacy endpoint, calls clearSource)
- * DELETE /api/proxy/epg/:sourceId/cache
- */
-router.delete('/epg/:sourceId/cache', (req, res) => {
-    const sourceId = req.params.sourceId;
-    cache.clear('epg', sourceId, 'data');
-    res.json({ success: true });
-});
-
-/**
- * Get EPG for specific channels
- * POST /api/proxy/epg/:sourceId/channels
- */
-router.post('/epg/:sourceId/channels', async (req, res) => {
+router.post("/epg/:sourceId/channels", async (req, res) => {
     try {
         const source = sources.getById(req.params.sourceId);
-        if (!source || source.type !== 'epg') {
-            return res.status(404).json({ error: 'EPG source not found' });
+        if (!source || source.type !== "epg") {
+            return res.status(404).json({ error: "EPG source not found" });
         }
-
         const { channelIds } = req.body;
         if (!channelIds || !Array.isArray(channelIds)) {
-            return res.status(400).json({ error: 'channelIds array required' });
+            return res.status(400).json({ error: "channelIds array required" });
         }
-
         const data = await epgParser.fetchAndParse(source.url);
-
-        // Filter programmes for requested channels
         const result = {};
         for (const channelId of channelIds) {
             result[channelId] = epgParser.getCurrentAndUpcoming(data.programmes, channelId);
         }
-
         res.json(result);
     } catch (err) {
-        console.error('EPG channels error:', err);
+        console.error("EPG channels error:", err);
         res.status(500).json({ error: err.message });
     }
 });
 
+// Cache referer per CDN hostname
+const streamRefererCache = new Map();
+
 /**
- * Proxy stream for playback
- * This handles CORS for streams that don't allow cross-origin
+ * Proxy stream for playback - handles CORS and referer issues
  */
-router.get('/stream', async (req, res) => {
+router.get("/stream", async (req, res) => {
     try {
-        let { url } = req.query;
+        let { url, referer } = req.query;
         if (!url) {
-            return res.status(400).json({ error: 'URL required' });
+            return res.status(400).json({ error: "URL required" });
         }
 
-        // Forward some headers to be more "transparent" back to the origin
-        const isPluto = url.includes('pluto.tv');
+        const urlObj = new URL(url);
+        const cacheKey = urlObj.hostname;
+
+        // Store referer for this CDN hostname if provided
+        if (referer) {
+            streamRefererCache.set(cacheKey, referer);
+        }
+
+        // Determine the best referer
+        let finalReferer = referer || streamRefererCache.get(cacheKey);
+
+        if (!finalReferer) {
+            if (url.includes("pluto.tv")) {
+                finalReferer = "https://pluto.tv/";
+            } else {
+                // For Xtream CDNs, use the Xtream portal URL as referer
+                const allSources = sources.getAll();
+                const xtreamSource = allSources.find(s => s.type === "xtream");
+                if (xtreamSource && xtreamSource.url) {
+                    finalReferer = xtreamSource.url;
+                    streamRefererCache.set(cacheKey, finalReferer);
+                } else {
+                    finalReferer = urlObj.origin + "/";
+                }
+            }
+        }
+
+        let refererOrigin;
+        try {
+            refererOrigin = new URL(finalReferer).origin;
+        } catch {
+            refererOrigin = urlObj.origin;
+        }
 
         const headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            'Accept': '*/*',
-            'Accept-Language': 'en-US,en;q=0.9',
-            // Using https and matching the origin of the request
-            'Origin': isPluto ? 'https://pluto.tv' : new URL(url).origin,
-            'Referer': isPluto ? 'https://pluto.tv/' : new URL(url).origin + '/'
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Origin": refererOrigin,
+            "Referer": finalReferer
         };
 
-        const response = await fetch(url, { headers });
+        console.log("Proxying:", url.substring(0, 80) + "... with Referer:", finalReferer);
+
+        const response = await fetch(url, { headers, redirect: "follow" });
         if (!response.ok) {
-            console.error(`Upstream error for ${url.substring(0, 80)}...: ${response.status} ${response.statusText}`);
-            // Log response body for debugging 403s
-            if (response.status === 403) {
-                const errorBody = await response.text().catch(() => 'N/A');
-                console.error(`403 Response body: ${errorBody.substring(0, 200)}`);
+            console.error("Upstream " + response.status + " for " + url);
+            return res.status(response.status).send("Failed: " + response.statusText);
+        }
+
+        // Use the final URL after redirects for base URL calculation
+        const finalUrl = response.url || url;
+        const finalUrlObj = new URL(finalUrl);
+
+        console.log("Final URL after redirects:", finalUrl.substring(0, 80));
+
+        const contentType = response.headers.get("content-type") || "";
+        res.set("Access-Control-Allow-Origin", "*");
+
+        const isHls = contentType.includes("mpegurl") ||
+                      contentType.includes("x-mpegURL") ||
+                      finalUrl.toLowerCase().includes(".m3u8");
+
+        if (isHls) {
+            let manifest = await response.text();
+
+            if (manifest.trim().startsWith("#EXTM3U")) {
+                res.set("Content-Type", "application/vnd.apple.mpegurl");
+
+                // Use the FINAL URL (after redirects) as the base for segment URLs
+                const baseUrl = finalUrlObj.origin + finalUrlObj.pathname.substring(0, finalUrlObj.pathname.lastIndexOf("/") + 1);
+                const proxyBase = req.protocol + "://" + req.get("host") + req.baseUrl + "/stream";
+
+                manifest = manifest.split("\n").map(line => {
+                    const trimmed = line.trim();
+                    if (trimmed === "" || trimmed.startsWith("#")) {
+                        if (trimmed.includes('URI="')) {
+                            return line.replace(/URI="([^"]+)"/g, (match, p1) => {
+                                try {
+                                    const absoluteUrl = new URL(p1, baseUrl).href;
+                                    return 'URI="' + proxyBase + '?url=' + encodeURIComponent(absoluteUrl) + '"';
+                                } catch { return match; }
+                            });
+                        }
+                        return line;
+                    }
+                    try {
+                        const absoluteUrl = new URL(trimmed, baseUrl).href;
+                        return proxyBase + "?url=" + encodeURIComponent(absoluteUrl);
+                    } catch { return line; }
+                }).join("\n");
+
+                return res.send(manifest);
             }
-            return res.status(response.status).send(`Failed to fetch stream: ${response.statusText}`);
         }
 
-        const contentType = response.headers.get('content-type') || '';
-        res.set('Access-Control-Allow-Origin', '*');
-
-        // Read response as array buffer
+        res.set("Content-Type", contentType);
         const buffer = await response.arrayBuffer();
-        const bytes = new Uint8Array(buffer);
-
-        // Check if it's an HLS manifest by looking at first bytes (#EXTM3U = 23 45 58 54 4D 33 55)
-        const textPrefix = String.fromCharCode(...bytes.slice(0, 7));
-        const contentLooksLikeHls = textPrefix === '#EXTM3U';
-        const urlLooksLikeHls = contentType.includes('mpegurl') || contentType.includes('application/x-mpegURL') || url.toLowerCase().includes('.m3u8');
-
-        if (contentLooksLikeHls) {
-            console.log(`[Proxy] Processing HLS manifest from: ${url.substring(0, 80)}...`);
-            res.set('Content-Type', 'application/vnd.apple.mpegurl');
-
-            let manifest = Buffer.from(buffer).toString('utf-8');
-            // Rewrite URLs inside manifest
-
-            const urlObj = new URL(url);
-            const baseUrl = urlObj.origin + urlObj.pathname.substring(0, urlObj.pathname.lastIndexOf('/') + 1);
-            console.log(`[Proxy] Base URL for rewriting: ${baseUrl}`);
-
-            manifest = manifest.split('\n').map(line => {
-                const trimmed = line.trim();
-                if (trimmed === '' || trimmed.startsWith('#')) {
-                    if (trimmed.includes('URI="')) {
-                        return line.replace(/URI="([^"]+)"/g, (match, p1) => {
-                            try {
-                                const absoluteUrl = new URL(p1, baseUrl).href;
-                                return `URI="${req.protocol}://${req.get('host')}${req.baseUrl}/stream?url=${encodeURIComponent(absoluteUrl)}"`;
-                            } catch (e) { return match; }
-                        });
-                    }
-                    return line;
-                }
-
-                // Check if it's a URL (segment or playlist reference)
-                try {
-                    // Handle both relative and absolute URLs
-                    let absoluteUrl;
-                    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-                        // Already an absolute URL
-                        absoluteUrl = trimmed;
-                    } else {
-                        // Relative URL - make it absolute
-                        absoluteUrl = new URL(trimmed, baseUrl).href;
-                    }
-                    return `${req.protocol}://${req.get('host')}${req.baseUrl}/stream?url=${encodeURIComponent(absoluteUrl)}`;
-                } catch (e) { return line; }
-            }).join('\n');
-
-            // Return rewritten manifest
-            return res.send(manifest);
-        }
-
-        // Binary content (segments)
-        res.set('Content-Type', contentType || 'application/octet-stream');
         return res.send(Buffer.from(buffer));
 
     } catch (err) {
-        console.error('Stream proxy error:', err);
+        console.error("Stream proxy error:", err);
         if (!res.headersSent) {
             res.status(500).json({ error: err.message });
         }


### PR DESCRIPTION
Adds a toggle in Settings → Player → Streaming to force all streams through the backend proxy.

**Key fix:** Uses final URL after redirects as base for HLS segment paths, resolving issues with Xtream CDNs that redirect to different servers.