### PR TITLE
Fix channel search filter for null channel names

### DIFF
--- a/public/js/components/ChannelList.js
+++ b/public/js/components/ChannelList.js
@@ -225,8 +225,8 @@ class ChannelList {
         this.filteredChannels = this.channels;
         if (searchTerm) {
             this.filteredChannels = this.channels.filter(ch =>
-                ch.name.toLowerCase().includes(searchTerm) ||
-                (ch.groupTitle && ch.groupTitle.toLowerCase().includes(searchTerm))
+                String(ch.name ?? "").toLowerCase().includes(searchTerm) ||
+                String(ch.groupTitle ?? "").toLowerCase().includes(searchTerm)
             );
         }
 


### PR DESCRIPTION
The current channel search filter does not check whether the channel name is null. Some of my lists contain channels or group header fields without a name property which are parsed as null. This causes the filter function to throw an error breaking the search function. 

To fix this issue, I have added a null check for the channel name to the filter function.