### PR TITLE
fix: Improve browser navigation and prevent login page in history

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -255,8 +255,8 @@
                 // Store token
                 localStorage.setItem('authToken', data.token);
 
-                // Redirect to main app
-                window.location.href = '/';
+                // Redirect to main app (replace history to prevent back button issues)
+                window.location.replace('/');
 
             } catch (err) {
                 errorMessage.textContent = err.message;


### PR DESCRIPTION
## Fix: Browser Navigation and Login Page History Issues

### Problem
When using the browser's back button:
- Users would be redirected to the login page even when authenticated
- No browser history support for navigating between app sections (Live TV, Movies, Settings, etc.)
- Unable to use back/forward buttons within the app

### Solution

**Browser History Management**
- Implemented History API (`pushState`/`replaceState`) for proper SPA navigation
- Added `popstate` event listener to handle back/forward button clicks
- URL hash support for each section (`#home`, `#movies`, `#series`, etc.)

**Login Page History Prevention**
- Changed all `window.location.href` to `window.location.replace()` when navigating to/from login
- Login page is now removed from browser history after successful authentication
- Prevents accidental navigation back to login while authenticated

### Files Changed
- `public/js/app.js` - Added history management and fixed redirects
- `public/login.html` - Use `replace()` instead of `href` for post-login redirect

### Impact
- Back button now navigates between app sections (Live TV → Movies → Series → Settings)
- Forward button navigation works correctly
- Sections are bookmarkable via URL hash
- Login page no longer appears in history after authentication
- Direct navigation to sections via URL works (e.g., `/#movies`)
- No impact on existing functionality