### PR TITLE
fix: resolve live TV playback failures

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -314,8 +314,10 @@ h4 {
    ===================================================== */
 .home-layout {
   display: flex;
-  height: 100%;
+  height: calc(100vh - var(--navbar-height));
+  height: calc(100dvh - var(--navbar-height));
   position: relative;
+  overflow: hidden;
 }
 
 /* Fix scroll sidebar on desktop (Safari / flex bug) */
@@ -675,6 +677,7 @@ h4 {
   display: flex;
   flex-direction: column;
   background: var(--color-bg-primary);
+  overflow: hidden;
 }
 
 .video-container {

--- a/public/js/components/VideoPlayer.js
+++ b/public/js/components/VideoPlayer.js
@@ -22,6 +22,7 @@ class VideoPlayer {
         this.overlay = document.getElementById('player-overlay');
         this.nowPlaying = document.getElementById('now-playing');
         this.hls = null;
+        this._playId = 0;
         this.currentChannel = null;
         this.overlayTimer = null;
         this.overlayDuration = 5000; // 5 seconds
@@ -813,22 +814,19 @@ class VideoPlayer {
      * Start a HLS transcode session
      */
     async startTranscodeSession(url, options = {}) {
-        try {
-            console.log('[Player] Starting HLS transcode session...', options);
-            const res = await fetch('/api/transcode/session', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ url, ...options })
-            });
-            if (!res.ok) throw new Error('Failed to start session');
-            const session = await res.json();
-            this.currentSessionId = session.sessionId;
-            return session.playlistUrl;
-        } catch (err) {
-            console.error('[Player] Session start failed:', err);
-            // Fallback to direct transcode if session fails
-            return `/api/transcode?url=${encodeURIComponent(url)}`;
+        console.log('[Player] Starting HLS transcode session...', options);
+        const res = await fetch('/api/transcode/session', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url, ...options })
+        });
+        if (!res.ok) {
+            const detail = await res.json().catch(() => ({}));
+            throw new Error(detail.reason || detail.error || 'Failed to start session');
         }
+        const session = await res.json();
+        this.currentSessionId = session.sessionId;
+        return session.playlistUrl;
     }
 
     /**
@@ -836,14 +834,14 @@ class VideoPlayer {
      */
     async stopTranscodeSession() {
         if (this.currentSessionId) {
-            console.log('[Player] Stopping transcode session:', this.currentSessionId);
+            const sessionId = this.currentSessionId;
+            this.currentSessionId = null;
+            console.log('[Player] Stopping transcode session:', sessionId);
             try {
-                // Fire and forget cleanup
-                fetch(`/api/transcode/${this.currentSessionId}`, { method: 'DELETE' });
+                await fetch(`/api/transcode/${sessionId}`, { method: 'DELETE' });
             } catch (err) {
                 console.error('Failed to stop session:', err);
             }
-            this.currentSessionId = null;
         }
     }
 
@@ -851,15 +849,21 @@ class VideoPlayer {
      * Play a channel
      */
     async play(channel, streamUrl) {
+        // Guard against overlapping play() calls (rapid channel switching)
+        const playId = ++this._playId;
         this.currentChannel = channel;
 
         try {
             // Stop any WatchPage playback (movies/series) before starting Live TV
             window.app?.pages?.watch?.stop?.();
 
-            // Stop current playback
+            // Stop current playback - await session cleanup to prevent concurrent connections
+            await this.stopTranscodeSession();
             this.stop();
             this.updateTranscodeStatus('hidden');
+
+            // Abort if another play() was called while we were stopping
+            if (this._playId !== playId) return;
 
             // Hide "select a channel" overlay
             this.overlay.classList.add('hidden');
@@ -876,6 +880,7 @@ class VideoPlayer {
                 console.log('[Player] Auto Transcode enabled. Probing stream...');
                 try {
                     const probeRes = await fetch(`/api/probe?url=${encodeURIComponent(streamUrl)}`);
+                    if (this._playId !== playId) return; // Abort if channel changed during probe
                     const info = await probeRes.json();
                     console.log(`[Player] Probe result: video=${info.video}, audio=${info.audio}, ${info.width}x${info.height}, compatible=${info.compatible}`);
 
@@ -916,15 +921,28 @@ class VideoPlayer {
                         const statusMode = this.settings.upscaleEnabled ? 'upscaling' : 'transcoding';
 
                         this.updateTranscodeStatus(statusMode, statusText);
-                        const playlistUrl = await this.startTranscodeSession(streamUrl, {
-                            videoMode,
-                            videoCodec: info.video,
-                            audioCodec: info.audio,
-                            audioChannels: info.audioChannels
-                        });
-                        this.currentUrl = playlistUrl; // Update currentUrl for HLS reload
+                        try {
+                            const playlistUrl = await this.startTranscodeSession(streamUrl, {
+                                videoMode,
+                                videoCodec: info.video,
+                                audioCodec: info.audio,
+                                audioChannels: info.audioChannels
+                            });
+                            if (this._playId !== playId) return; // Abort if channel changed during session start
+                            this.currentUrl = playlistUrl; // Update currentUrl for HLS reload
 
-                        this.playHls(playlistUrl);
+                            this.playHls(playlistUrl);
+                        } catch (sessionErr) {
+                            console.warn('[Player] Transcode session failed, falling back to direct transcode:', sessionErr.message);
+                            if (this._playId !== playId) return;
+                            // Fallback: direct transcode as fragmented MP4 (not HLS)
+                            const directUrl = `/api/transcode?url=${encodeURIComponent(streamUrl)}`;
+                            this.currentUrl = directUrl;
+                            this.video.src = directUrl;
+                            this.video.play().catch(e => {
+                                if (e.name !== 'AbortError') console.error('[Player] Direct transcode fallback failed:', e);
+                            });
+                        }
 
                         this.updateNowPlaying(channel);
                         this.showNowPlayingOverlay();
@@ -1190,6 +1208,7 @@ class VideoPlayer {
      * Helper to play HLS stream (reduces duplication)
      */
     playHls(url) {
+        console.log('[Player] playHls loading:', url);
         if (this.hls) {
             this.hls.destroy();
         }
@@ -1198,17 +1217,25 @@ class VideoPlayer {
         this.hls.loadSource(url);
         this.hls.attachMedia(this.video);
 
-        this.hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        this.hls.on(Hls.Events.MANIFEST_PARSED, (event, data) => {
+            console.log('[Player] HLS manifest parsed, levels:', data.levels?.length);
+            this.loadingSpinner?.classList.remove('show');
             this.video.play().catch(e => {
                 if (e.name !== 'AbortError') console.log('Autoplay prevented:', e);
             });
         });
 
         this.hls.on(Hls.Events.ERROR, (event, data) => {
+            console.warn('[Player] HLS error:', data.type, data.details, data.fatal ? '(FATAL)' : '');
             if (data.fatal) {
-                // Simple error handling for forced HLS/transcode modes
-                console.error('Fatal HLS error in transcode mode:', data);
-                this.hls.destroy();
+                if (data.type === Hls.ErrorTypes.MEDIA_ERROR) {
+                    console.log('[Player] Attempting media error recovery...');
+                    this.hls.recoverMediaError();
+                } else {
+                    // Network or other fatal error - clean up transcode session
+                    this.stopTranscodeSession();
+                    this.hls.destroy();
+                }
             }
         });
     }

--- a/server/routes/transcode.js
+++ b/server/routes/transcode.js
@@ -40,7 +40,7 @@ router.post('/session', async (req, res) => {
     const userAgent = db.getUserAgent(settings);
 
     try {
-        const session = await transcodeSession.createSession(url, {
+        const session = await transcodeSession.getOrCreateSession(url, {
             ffmpegPath,
             userAgent,
             seekOffset: seekOffset || 0,
@@ -58,14 +58,22 @@ router.post('/session', async (req, res) => {
             audioChannels: audioChannels // number of channels (2=stereo)
         });
 
-        await session.start();
+        // Only start and wait if not already running (getOrCreateSession may return existing)
+        if (session.status !== 'running') {
+            await session.start();
 
-        // Wait for playlist to be ready (first segments generated)
-        const ready = await session.waitForPlaylist(15000);
+            // Wait for playlist to be ready (first segments generated)
+            console.log(`[Transcode] Waiting for playlist (session ${session.id})...`);
+            const ready = await session.waitForPlaylist(20000);
 
-        if (!ready) {
-            await transcodeSession.removeSession(session.id);
-            return res.status(500).json({ error: 'Transcoding failed to start', reason: 'Playlist not generated in time' });
+            if (!ready) {
+                console.error(`[Transcode] Playlist timeout for session ${session.id} (status: ${session.status})`);
+                await transcodeSession.removeSession(session.id);
+                return res.status(500).json({ error: 'Transcoding failed to start', reason: 'Playlist not generated in time' });
+            }
+            console.log(`[Transcode] Playlist ready for session ${session.id}`);
+        } else {
+            console.log(`[Transcode] Reusing existing session ${session.id}`);
         }
 
         res.json({

--- a/server/services/transcodeSession.js
+++ b/server/services/transcodeSession.js
@@ -193,14 +193,17 @@ class TranscodeSession extends EventEmitter {
         }
 
         // Input options (common)
+        // Lower probe/analyze values for faster startup (we already probed separately)
         args.push(
-            '-probesize', '5000000',
-            '-analyzeduration', '5000000',
+            '-probesize', '2000000',
+            '-analyzeduration', '3000000',
             '-fflags', '+genpts+discardcorrupt',
             '-err_detect', 'ignore_err',
             '-reconnect', '1',
             '-reconnect_streamed', '1',
-            '-reconnect_delay_max', '3'
+            '-reconnect_delay_max', '3',
+            // Prevent Range/HEAD requests that some providers reject
+            '-seekable', '0'
         );
 
         args.push('-i', this.url);
@@ -218,13 +221,18 @@ class TranscodeSession extends EventEmitter {
         if (videoMode === 'copy') {
             args.push('-c:v', 'copy');
 
-            // Critical for MKV/MP4 -> TS copy: Convert bitstream from AVCC/HVCC to Annex B
-            if (this.options.videoCodec === 'hevc' || this.options.videoCodec === 'h265') {
+            // Bitstream filter: only needed for MP4/MKV -> TS (AVCC/HVCC to Annex B)
+            // HLS/TS sources already use Annex B, so use dump_extra to ensure SPS/PPS
+            // are present at keyframes without risking corruption from mp4toannexb
+            const isHlsOrTs = this.url.includes('.m3u8') || this.url.includes('.ts');
+            if (isHlsOrTs) {
+                // TS/HLS input: just ensure extradata is in the bitstream
+                args.push('-bsf:v', 'dump_extra');
+            } else if (this.options.videoCodec === 'hevc' || this.options.videoCodec === 'h265') {
                 args.push('-bsf:v', 'hevc_mp4toannexb');
             } else if (this.options.videoCodec === 'h264' || this.options.videoCodec === 'avc') {
                 args.push('-bsf:v', 'h264_mp4toannexb');
             } else {
-                // Fallback (e.g. unknown codec), try strict extraction
                 args.push('-bsf:v', 'dump_extra');
             }
         } else {


### PR DESCRIPTION
## Summary

- **Fix live TV completely broken** — clicking a channel produced FFmpeg errors, HTTP 509 bandwidth limits, and no visible video player
- **Root causes**: duplicate transcode sessions, wrong FFmpeg flags for live streams, client-side race conditions, and a CSS layout bug where 34k channels stretched the video container to ~16000px tall
- **4 files changed** across server transcode pipeline, player JS, and CSS layout

## What was fixed

### Server-side (transcode pipeline)
- Use `getOrCreateSession()` instead of `createSession()` to prevent duplicate FFmpeg processes for the same stream URL (caused HTTP 509 from providers)
- Add `-seekable 0` to session FFmpeg args to prevent Range/HEAD requests that IPTV providers reject
- Reduce `probesize`/`analyzeduration` (5MB/5s → 2MB/3s) for faster first segment generation — stream is already probed separately
- Use `dump_extra` BSF instead of `h264_mp4toannexb` for HLS/TS inputs to avoid corrupting Annex B streams when joining mid-stream without SPS/PPS
- Increase `waitForPlaylist` timeout to 20s with diagnostic logging

### Client-side (VideoPlayer.js)
- Add `play()` race condition guard (`_playId`) to prevent overlapping async calls from creating orphaned transcode sessions during rapid channel switching
- Await `stopTranscodeSession()` DELETE before starting new sessions to prevent concurrent provider connections
- Fix broken silent fallback in `startTranscodeSession` — now throws on failure so caller can fall back to direct transcode on the video element properly
- Add media error recovery and session cleanup in `playHls()` error handler

### CSS (main.css)
- Fix `.home-layout` height from `100%` to `calc(100dvh - var(--navbar-height))` — with 34k channels the sidebar content stretched the flex container to ~16000px, pushing the video completely off-screen (audio played but video was invisible)
- Add `overflow: hidden` to `.home-layout` and `.player-section`

## Test plan

- [ ] Load a live TV channel — video and audio should both play
- [ ] Rapidly switch between channels — no orphaned FFmpeg processes or 509 errors
- [ ] Verify movies/series playback still works (unchanged code paths)
- [ ] Check channel sidebar still scrolls properly with large channel lists
- [ ] Verify layout on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)