### PR TITLE
feat: detect movies and series from M3U sources

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -134,10 +134,10 @@ const API = {
                 return API.request('GET', `/proxy/xtream/${sourceId}/series${query}`);
             },
             seriesInfo: (sourceId, seriesId) =>
-                API.request('GET', `/proxy/xtream/${sourceId}/series_info?series_id=${seriesId}`),
+                API.request('GET', `/proxy/xtream/${sourceId}/series_info?series_id=${encodeURIComponent(seriesId)}`),
             shortEpg: (sourceId, streamId) => API.request('GET', `/proxy/xtream/${sourceId}/short_epg?stream_id=${streamId}`),
             getStreamUrl: (sourceId, streamId, type = 'live', container = 'm3u8') =>
-                API.request('GET', `/proxy/xtream/${sourceId}/stream/${streamId}/${type}?container=${container}`)
+                API.request('GET', `/proxy/xtream/${sourceId}/stream/${encodeURIComponent(streamId)}/${type}?container=${encodeURIComponent(container)}`)
         },
 
         // EPG

--- a/public/js/pages/MoviesPage.js
+++ b/public/js/pages/MoviesPage.js
@@ -93,7 +93,7 @@ class MoviesPage {
     async loadSources() {
         try {
             const allSources = await API.sources.getAll();
-            this.sources = allSources.filter(s => s.type === 'xtream' && s.enabled);
+            this.sources = allSources.filter(s => ['xtream', 'm3u'].includes(s.type) && s.enabled);
 
             this.sourceSelect.innerHTML = '<option value="">All Sources</option>';
             this.sources.forEach(s => {

--- a/public/js/pages/SeriesPage.js
+++ b/public/js/pages/SeriesPage.js
@@ -105,7 +105,7 @@ class SeriesPage {
     async loadSources() {
         try {
             const allSources = await API.sources.getAll();
-            this.sources = allSources.filter(s => s.type === 'xtream' && s.enabled);
+            this.sources = allSources.filter(s => ['xtream', 'm3u'].includes(s.type) && s.enabled);
 
             this.sourceSelect.innerHTML = '<option value="">All Sources</option>';
             this.sources.forEach(s => {

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -36,7 +36,7 @@ function getCategoriesFromDb(sourceId, type, includeHidden = false) {
 function getStreamsFromDb(sourceId, type, categoryId = null, includeHidden = false) {
     const db = getDb();
     let query = `
-        SELECT item_id, name, stream_icon, added_at, rating, container_extension, year, category_id, data
+        SELECT item_id, name, parent_id, stream_icon, stream_url, added_at, rating, container_extension, year, category_id, data
         FROM playlist_items 
         WHERE source_id = ? AND type = ?
     `;
@@ -67,14 +67,95 @@ function getStreamsFromDb(sourceId, type, categoryId = null, includeHidden = fal
             name: item.name,
             stream_icon: item.stream_icon,
             cover: item.stream_icon, // series/vod often use cover
+            stream_url: item.stream_url || data.stream_url || null,
             added: item.added_at,
             rating: item.rating,
             container_extension: item.container_extension,
             category_id: item.category_id,
+            parent_id: item.parent_id,
             // Normalize EPG channel ID: Xtream uses epg_channel_id, M3U uses tvgId
             epg_channel_id: data.epg_channel_id || data.tvgId || null
         };
     });
+}
+
+function getM3uStreamUrl(sourceId, itemId, type) {
+    const db = getDb();
+    const dbType = type === 'series' ? 'episode' : type;
+    const row = db.prepare(`
+        SELECT stream_url, data
+        FROM playlist_items
+        WHERE source_id = ? AND type = ? AND item_id = ?
+        LIMIT 1
+    `).get(sourceId, dbType, String(itemId));
+
+    if (!row) return null;
+
+    const data = JSON.parse(row.data || '{}');
+    return row.stream_url || data.stream_url || data.url || null;
+}
+
+function getM3uSeriesInfo(sourceId, seriesId) {
+    const db = getDb();
+    const seriesRow = db.prepare(`
+        SELECT item_id, name, stream_icon, rating, year, data
+        FROM playlist_items
+        WHERE source_id = ? AND type = 'series' AND item_id = ?
+        LIMIT 1
+    `).get(sourceId, String(seriesId));
+
+    if (!seriesRow) {
+        return null;
+    }
+
+    const seriesData = JSON.parse(seriesRow.data || '{}');
+    const episodeRows = db.prepare(`
+        SELECT item_id, name, parent_id, stream_icon, stream_url, container_extension, year, data
+        FROM playlist_items
+        WHERE source_id = ? AND type = 'episode' AND parent_id = ? AND is_hidden = 0
+    `).all(sourceId, String(seriesId));
+
+    const episodes = {};
+
+    for (const row of episodeRows) {
+        const data = JSON.parse(row.data || '{}');
+        const seasonNum = String(data.season_num || 1);
+        if (!episodes[seasonNum]) {
+            episodes[seasonNum] = [];
+        }
+
+        episodes[seasonNum].push({
+            ...data,
+            id: row.item_id,
+            title: data.title || row.name,
+            episode_num: data.episode_num || 1,
+            season_num: data.season_num || 1,
+            container_extension: row.container_extension || data.container_extension || 'mp4',
+            stream_icon: row.stream_icon || data.stream_icon || null,
+            stream_url: row.stream_url || data.stream_url || null,
+            year: row.year || data.year || null
+        });
+    }
+
+    Object.values(episodes).forEach(list => {
+        list.sort((a, b) => {
+            const seasonDiff = (a.season_num || 1) - (b.season_num || 1);
+            if (seasonDiff !== 0) return seasonDiff;
+            return (a.episode_num || 1) - (b.episode_num || 1);
+        });
+    });
+
+    return {
+        info: {
+            ...seriesData,
+            series_id: seriesRow.item_id,
+            name: seriesRow.name,
+            cover: seriesRow.stream_icon,
+            rating: seriesRow.rating,
+            year: seriesRow.year || seriesData.releaseDate || null
+        },
+        episodes
+    };
 }
 
 
@@ -195,8 +276,15 @@ router.get('/xtream/:sourceId/series_info', async (req, res) => {
         const cached = cache.get('xtream', source.id, cacheKey, 3600000);
         if (cached) return res.json(cached);
 
-        const api = xtreamApi.createFromSource(source);
-        const data = await api.getSeriesInfo(seriesId);
+        let data;
+        if (source.type === 'm3u') {
+            data = getM3uSeriesInfo(source.id, seriesId);
+            if (!data) return res.status(404).json({ error: 'Series not found' });
+        } else {
+            const api = xtreamApi.createFromSource(source);
+            data = await api.getSeriesInfo(seriesId);
+        }
+
         cache.set('xtream', source.id, cacheKey, data);
         res.json(data);
     } catch (err) {
@@ -231,13 +319,21 @@ router.get('/xtream/:sourceId/vod_info', async (req, res) => {
 router.get('/xtream/:sourceId/stream/:streamId/:type', async (req, res) => {
     try {
         const source = await sources.getById(req.params.sourceId);
-        if (!source || source.type !== 'xtream') {
-            return res.status(404).json({ error: 'Xtream source not found' });
+        if (!source || !['xtream', 'm3u'].includes(source.type)) {
+            return res.status(404).json({ error: 'Source not found' });
         }
 
         const streamId = req.params.streamId;
         const type = req.params.type || 'live';
         const container = req.query.container || 'm3u8';
+
+        if (source.type === 'm3u') {
+            const streamUrl = getM3uStreamUrl(source.id, streamId, type);
+            if (!streamUrl) {
+                return res.status(404).json({ error: 'M3U stream not found' });
+            }
+            return res.json({ url: streamUrl });
+        }
 
         // Construct the Xtream stream URL
         // Format: http://server:port/live/username/password/streamId.container (for live)

--- a/server/services/m3uClassifier.js
+++ b/server/services/m3uClassifier.js
@@ -1,0 +1,177 @@
+const VIDEO_EXTENSIONS = new Set([
+    'mp4', 'mkv', 'avi', 'mov', 'wmv', 'm4v', 'webm', 'ts', 'm2ts', 'mpeg', 'mpg', 'flv'
+]);
+
+const MOVIE_KEYWORDS = [
+    'movie', 'movies', 'vod', 'film', 'films', 'cinema', 'filme', 'filmes'
+];
+
+const SERIES_KEYWORDS = [
+    'series', 'tv show', 'tv shows', 'show', 'shows', 'anime', 'novela', 'novelas',
+    'season', 'seasons', 'temporada', 'temporadas', 'episode', 'episodes', 'episodio', 'episodios'
+];
+
+function stableHash(value) {
+    const input = String(value || 'unknown');
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+        hash = ((hash << 5) - hash) + input.charCodeAt(i);
+        hash |= 0;
+    }
+    return Math.abs(hash).toString(36);
+}
+
+function normalizeText(value) {
+    return String(value || '')
+        .replace(/\.[a-z0-9]{2,4}(?=$|\?)/ig, '')
+        .replace(/[._]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function includesKeyword(haystack, keywords) {
+    const text = String(haystack || '').toLowerCase();
+    return keywords.some(keyword => text.includes(keyword));
+}
+
+function getUrlPathname(url) {
+    try {
+        return new URL(url).pathname.toLowerCase();
+    } catch {
+        return String(url || '').toLowerCase();
+    }
+}
+
+function getContainerExtension(url) {
+    const pathname = getUrlPathname(url);
+    const match = pathname.match(/\.([a-z0-9]{2,5})(?:$|\?)/i);
+    return match ? match[1].toLowerCase() : null;
+}
+
+function extractYear(text) {
+    const match = String(text || '').match(/\b(19|20)\d{2}\b/);
+    return match ? match[0] : null;
+}
+
+function parseEpisodeMetadata(name) {
+    const cleaned = normalizeText(name);
+    if (!cleaned) return null;
+
+    const patterns = [
+        /^(.*?)[\s\-_:]*s(\d{1,2})[\s\-_:]*e(\d{1,3})(?:[\s\-_:]+(.*))?$/i,
+        /^(.*?)[\s\-_:]*(\d{1,2})x(\d{1,3})(?:[\s\-_:]+(.*))?$/i,
+        /^(.*?)[\s\-_:]*(?:season|temporada)\s*(\d{1,2})[\s\-_:]*(?:episode|episodio|ep)\s*(\d{1,3})(?:[\s\-_:]+(.*))?$/i
+    ];
+
+    for (const pattern of patterns) {
+        const match = cleaned.match(pattern);
+        if (match) {
+            const seriesTitle = normalizeText(match[1]);
+            const seasonNum = parseInt(match[2], 10);
+            const episodeNum = parseInt(match[3], 10);
+            const remainder = normalizeText(match[4]);
+
+            if (!seriesTitle || Number.isNaN(seasonNum) || Number.isNaN(episodeNum)) {
+                continue;
+            }
+
+            return {
+                seriesTitle,
+                seasonNum,
+                episodeNum,
+                episodeTitle: remainder || `Episode ${episodeNum}`
+            };
+        }
+    }
+
+    return null;
+}
+
+function deriveSeriesFallback(name) {
+    const cleaned = normalizeText(name);
+    if (!cleaned) return null;
+
+    return {
+        seriesTitle: cleaned,
+        seasonNum: 1,
+        episodeNum: 1,
+        episodeTitle: cleaned
+    };
+}
+
+function makeCategoryId(type, groupTitle) {
+    return `${type}:${normalizeText(groupTitle || 'Uncategorized') || 'Uncategorized'}`;
+}
+
+function makeSeriesId(groupTitle, seriesTitle) {
+    return `m3u_series_${stableHash(`${groupTitle}|${seriesTitle}`)}`;
+}
+
+function classifyEntry(entry) {
+    const groupTitle = normalizeText(entry.groupTitle || 'Uncategorized') || 'Uncategorized';
+    const name = normalizeText(entry.name || entry.tvgName || '');
+    const url = String(entry.url || '');
+    const extension = getContainerExtension(url);
+    const duration = Number(entry.duration);
+
+    const groupLower = groupTitle.toLowerCase();
+    const nameLower = name.toLowerCase();
+    const urlLower = url.toLowerCase();
+
+    const episodeMeta = parseEpisodeMetadata(name);
+    const hasSeriesKeyword = includesKeyword(groupLower, SERIES_KEYWORDS)
+        || urlLower.includes('/series/');
+    const hasMovieKeyword = includesKeyword(groupLower, MOVIE_KEYWORDS)
+        || urlLower.includes('/movie/')
+        || urlLower.includes('/vod/');
+    const hasVideoFileExtension = extension ? VIDEO_EXTENSIONS.has(extension) : false;
+    const looksFiniteVod = Number.isFinite(duration) && duration > 0;
+
+    if (episodeMeta) {
+        return {
+            mediaType: 'episode',
+            groupTitle,
+            containerExtension: extension || 'mp4',
+            year: extractYear(name),
+            seriesId: makeSeriesId(groupTitle, episodeMeta.seriesTitle),
+            ...episodeMeta
+        };
+    }
+
+    if (hasSeriesKeyword && (hasVideoFileExtension || looksFiniteVod || hasMovieKeyword)) {
+        const fallback = deriveSeriesFallback(name);
+        if (fallback) {
+            return {
+                mediaType: 'episode',
+                groupTitle,
+                containerExtension: extension || 'mp4',
+                year: extractYear(name),
+                seriesId: makeSeriesId(groupTitle, fallback.seriesTitle),
+                ...fallback
+            };
+        }
+    }
+
+    if (hasMovieKeyword || hasVideoFileExtension || looksFiniteVod) {
+        return {
+            mediaType: 'movie',
+            groupTitle,
+            containerExtension: extension || 'mp4',
+            year: extractYear(name)
+        };
+    }
+
+    return {
+        mediaType: 'live',
+        groupTitle,
+        containerExtension: extension
+    };
+}
+
+module.exports = {
+    classifyEntry,
+    makeCategoryId,
+    makeSeriesId,
+    normalizeText,
+    stableHash
+};

--- a/server/services/syncService.js
+++ b/server/services/syncService.js
@@ -2,6 +2,7 @@ const { getDb } = require('../db/sqlite');
 const { sources, settings } = require('../db'); // For source config and settings
 const xtreamApi = require('./xtreamApi');
 const m3uParser = require('./m3uParser');
+const { classifyEntry, makeCategoryId, stableHash } = require('./m3uClassifier');
 const epgParser = require('./epgParser');
 
 // Sync tracking
@@ -270,22 +271,27 @@ class SyncService {
         const stmt = db.prepare(`
             INSERT INTO playlist_items (
                 id, source_id, item_id, type, name, category_id, 
-                stream_icon, stream_url, container_extension, 
+                parent_id, stream_icon, stream_url, container_extension, 
                 rating, year, added_at, data
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
+                parent_id = excluded.parent_id,
                 name = excluded.name,
                 category_id = excluded.category_id,
                 stream_icon = excluded.stream_icon,
+                stream_url = excluded.stream_url,
                 container_extension = excluded.container_extension,
+                rating = excluded.rating,
+                year = excluded.year,
+                added_at = excluded.added_at,
                 data = excluded.data
         `);
 
         const insertBatch = db.transaction((batch) => {
             for (const item of batch) {
                 // Map fields based on type
-                let itemId, name, catId, icon, container;
+                let itemId, name, catId, icon, container, parentId = null, streamUrl = null;
                 let rating = null, year = null, added = null;
 
                 if (type === 'live') {
@@ -294,6 +300,7 @@ class SyncService {
                     catId = item.category_id;
                     icon = item.stream_icon;
                     added = item.added;
+                    streamUrl = item.stream_url || item.url || null;
                 } else if (type === 'movie') {
                     itemId = item.stream_id;
                     name = item.name || `Movie ${item.stream_id}`;
@@ -301,15 +308,27 @@ class SyncService {
                     icon = item.stream_icon; // or cover
                     container = item.container_extension;
                     rating = item.rating;
+                    year = item.year;
                     added = item.added;
+                    streamUrl = item.stream_url || item.url || null;
                 } else if (type === 'series') {
                     itemId = item.series_id;
                     name = item.name || `Series ${item.series_id}`;
                     catId = item.category_id;
-                    icon = item.cover;
+                    icon = item.cover || item.stream_icon;
                     rating = item.rating;
-                    year = item.releaseDate;
+                    year = item.releaseDate || item.year;
                     added = item.last_modified;
+                } else if (type === 'episode') {
+                    itemId = item.stream_id;
+                    name = item.name || item.title || `Episode ${item.stream_id}`;
+                    catId = item.category_id;
+                    parentId = item.parent_id || item.series_id || null;
+                    icon = item.stream_icon || item.cover;
+                    container = item.container_extension;
+                    year = item.year;
+                    added = item.added;
+                    streamUrl = item.stream_url || item.url || null;
                 }
 
                 const id = `${sourceId}:${itemId}`;
@@ -322,8 +341,9 @@ class SyncService {
                     type,
                     name,
                     String(catId),
+                    parentId,
                     icon,
-                    null, // Direct URL not stored for Xtream usually, built on fly
+                    streamUrl,
                     container,
                     rating,
                     year,
@@ -348,6 +368,18 @@ class SyncService {
 
         console.log(`[Sync] Saved ${items.length} ${type} items`);
         return syncedIds;
+    }
+
+    purgeAllItemsByType(sourceId, type) {
+        const db = getDb();
+        const deleted = db.prepare(`
+            DELETE FROM playlist_items
+            WHERE source_id = ? AND type = ?
+        `).run(sourceId, type);
+
+        if (deleted.changes > 0) {
+            console.log(`[Sync] Purged all ${deleted.changes} ${type} items`);
+        }
     }
 
     /**
@@ -507,58 +539,183 @@ class SyncService {
 
         logMemory();
 
-        const allGroups = new Set();
-        const allSyncedIds = new Set(); // Collect IDs across all batches
-        let totalChannels = 0;
+        const liveGroups = new Set();
+        const movieGroups = new Set();
+        const seriesGroups = new Set();
+        const liveSyncedIds = new Set();
+        const movieSyncedIds = new Set();
+        const episodeSyncedIds = new Set();
+        const seriesSyncedIds = new Set();
+        const seriesMap = new Map();
+        let totalEntries = 0;
+        let totalLive = 0;
+        let totalMovies = 0;
+        let totalEpisodes = 0;
         let batchCount = 0;
 
         // Stream and process in batches (default 500 channels per batch)
         for await (const batch of m3uParser.fetchAndParseStreaming(source.url)) {
             batchCount++;
 
-            // Map M3U channel format to our schema
-            const playlistItems = batch.channels.map(ch => ({
-                stream_id: ch.id,
-                name: ch.name,
-                category_id: ch.groupTitle || 'Uncategorized',
-                stream_icon: ch.tvgLogo,
-                stream_url: ch.url,
-                tvgId: ch.tvgId || null,
-            }));
+            const liveItems = [];
+            const movieItems = [];
+            const episodeItems = [];
 
-            // Save this batch immediately (skip purge - we'll do it at the end)
-            if (playlistItems.length > 0) {
-                const batchIds = await this.saveStreams(source.id, 'live', playlistItems, { skipPurge: true });
-                batchIds.forEach(id => allSyncedIds.add(id));
-                totalChannels += playlistItems.length;
+            for (const ch of batch.channels) {
+                const classification = classifyEntry(ch);
+                const baseData = {
+                    tvgId: ch.tvgId || null,
+                    tvgName: ch.tvgName || null,
+                    tvgLogo: ch.tvgLogo || null,
+                    groupTitle: classification.groupTitle,
+                    originalName: ch.name,
+                    duration: ch.duration,
+                    stream_url: ch.url
+                };
+
+                totalEntries++;
+
+                if (classification.mediaType === 'movie') {
+                    const categoryId = makeCategoryId('movie', classification.groupTitle);
+                    movieGroups.add(classification.groupTitle);
+                    movieItems.push({
+                        stream_id: `m3u_movie_${stableHash(ch.id)}`,
+                        name: ch.name,
+                        category_id: categoryId,
+                        stream_icon: ch.tvgLogo,
+                        stream_url: ch.url,
+                        container_extension: classification.containerExtension,
+                        year: classification.year,
+                        ...baseData
+                    });
+                    totalMovies++;
+                    continue;
+                }
+
+                if (classification.mediaType === 'episode') {
+                    const categoryId = makeCategoryId('series', classification.groupTitle);
+                    seriesGroups.add(classification.groupTitle);
+
+                    const episode = {
+                        stream_id: `m3u_episode_${stableHash(ch.id)}`,
+                        name: `${classification.seriesTitle} - ${classification.episodeTitle}`,
+                        title: classification.episodeTitle,
+                        category_id: categoryId,
+                        series_id: classification.seriesId,
+                        parent_id: classification.seriesId,
+                        stream_icon: ch.tvgLogo,
+                        stream_url: ch.url,
+                        container_extension: classification.containerExtension,
+                        season_num: classification.seasonNum,
+                        episode_num: classification.episodeNum,
+                        duration: Number.isFinite(ch.duration) && ch.duration > 0 ? ch.duration : null,
+                        year: classification.year,
+                        ...baseData
+                    };
+
+                    episodeItems.push(episode);
+                    totalEpisodes++;
+
+                    if (!seriesMap.has(classification.seriesId)) {
+                        seriesMap.set(classification.seriesId, {
+                            series_id: classification.seriesId,
+                            name: classification.seriesTitle,
+                            category_id: categoryId,
+                            cover: ch.tvgLogo,
+                            stream_icon: ch.tvgLogo,
+                            releaseDate: classification.year,
+                            tvgId: ch.tvgId || null,
+                            episodeCount: 0
+                        });
+                    }
+
+                    const series = seriesMap.get(classification.seriesId);
+                    series.episodeCount += 1;
+                    if (!series.cover && ch.tvgLogo) {
+                        series.cover = ch.tvgLogo;
+                        series.stream_icon = ch.tvgLogo;
+                    }
+                    if (!series.releaseDate && classification.year) {
+                        series.releaseDate = classification.year;
+                    }
+                    continue;
+                }
+
+                liveGroups.add(classification.groupTitle);
+                liveItems.push({
+                    stream_id: ch.id,
+                    name: ch.name,
+                    category_id: classification.groupTitle || 'Uncategorized',
+                    stream_icon: ch.tvgLogo,
+                    stream_url: ch.url,
+                    tvgId: ch.tvgId || null,
+                    ...baseData
+                });
+                totalLive++;
             }
 
-            // Collect groups for category creation at the end
-            batch.groups.forEach(g => allGroups.add(g));
+            if (liveItems.length > 0) {
+                const batchIds = await this.saveStreams(source.id, 'live', liveItems, { skipPurge: true });
+                batchIds.forEach(id => liveSyncedIds.add(id));
+            }
+
+            if (movieItems.length > 0) {
+                const batchIds = await this.saveStreams(source.id, 'movie', movieItems, { skipPurge: true });
+                batchIds.forEach(id => movieSyncedIds.add(id));
+            }
+
+            if (episodeItems.length > 0) {
+                const batchIds = await this.saveStreams(source.id, 'episode', episodeItems, { skipPurge: true });
+                batchIds.forEach(id => episodeSyncedIds.add(id));
+            }
 
             // Log progress every 10 batches
             if (batchCount % 10 === 0) {
-                console.log(`[Sync] Processed ${totalChannels} channels so far...`);
+                console.log(`[Sync] Processed ${totalEntries} M3U entries so far...`);
                 logMemory();
             }
         }
 
-        console.log(`[Sync] M3U Parsed: ${totalChannels} channels, ${allGroups.size} groups`);
-        logMemory();
-
-        // Purge stale items after all batches are complete
-        if (allSyncedIds.size > 0) {
-            await this.purgeStaleItems(source.id, 'live', allSyncedIds);
+        const seriesItems = Array.from(seriesMap.values());
+        if (seriesItems.length > 0) {
+            const batchIds = await this.saveStreams(source.id, 'series', seriesItems, { skipPurge: true });
+            batchIds.forEach(id => seriesSyncedIds.add(id));
         }
 
-        // Save Categories (Groups) at the end
-        const categories = Array.from(allGroups).map(name => ({
+        console.log(`[Sync] M3U Parsed: ${totalEntries} entries (${totalLive} live, ${totalMovies} movies, ${seriesItems.length} series, ${totalEpisodes} episodes)`);
+        logMemory();
+
+        if (liveSyncedIds.size > 0) await this.purgeStaleItems(source.id, 'live', liveSyncedIds);
+        else this.purgeAllItemsByType(source.id, 'live');
+
+        if (movieSyncedIds.size > 0) await this.purgeStaleItems(source.id, 'movie', movieSyncedIds);
+        else this.purgeAllItemsByType(source.id, 'movie');
+
+        if (seriesSyncedIds.size > 0) await this.purgeStaleItems(source.id, 'series', seriesSyncedIds);
+        else this.purgeAllItemsByType(source.id, 'series');
+
+        if (episodeSyncedIds.size > 0) await this.purgeStaleItems(source.id, 'episode', episodeSyncedIds);
+        else this.purgeAllItemsByType(source.id, 'episode');
+
+        const liveCategories = Array.from(liveGroups).map(name => ({
             category_id: name,
             category_name: name,
             parent_id: null
         }));
+        const movieCategories = Array.from(movieGroups).map(name => ({
+            category_id: makeCategoryId('movie', name),
+            category_name: name,
+            parent_id: null
+        }));
+        const seriesCategories = Array.from(seriesGroups).map(name => ({
+            category_id: makeCategoryId('series', name),
+            category_name: name,
+            parent_id: null
+        }));
 
-        await this.saveCategories(source.id, 'live', categories);
+        await this.saveCategories(source.id, 'live', liveCategories);
+        await this.saveCategories(source.id, 'movie', movieCategories);
+        await this.saveCategories(source.id, 'series', seriesCategories);
         console.log(`[Sync] M3U sync complete for ${source.name}`);
     }
 


### PR DESCRIPTION
## Summary
Adds heuristic M3U classification so plain M3U sources can populate Movies and Series instead of being imported as Live TV only.

## What changed
- added M3U classifier for live/movie/episode detection
- synthesize series entries from episodic M3U items
- store/play direct M3U VOD and episode URLs through existing proxy routes
- include M3U sources in Movies and Series pages
- URL-encode generated item IDs for playback and series info requests

## Notes
Detection is based on:
- group names
- episode naming patterns like `S01E01` and `1x02`
- media extensions and playlist metadata
