### PR TITLE
Add Enigma2/OpenWebif M3U support with program mapping and optional zap-before-streaming

### DIFF
--- a/public/js/components/ChannelList.js
+++ b/public/js/components/ChannelList.js
@@ -820,6 +820,8 @@ class ChannelList {
             this.groups = [];
         }
 
+        const source = await API.sources.getById(sourceId);
+
         // Use Xtream API endpoints - backend now supports M3U sources too
         const categories = await API.proxy.xtream.liveCategories(sourceId);
         const streams = await API.proxy.xtream.liveStreams(sourceId);
@@ -842,6 +844,9 @@ class ChannelList {
             tvgId: stream.epg_channel_id,
             tvgLogo: stream.stream_icon,
             url: stream.stream_url, // M3U has direct URLs
+            program: stream.program || null,
+            zapBeforeStreaming: source?.zapBeforeStreaming || false,
+            zapDelay: source?.zapDelay || 1500,
             groupId: `m3u_${sourceId}_${stream.category_id}`,
             groupTitle: categories.find(c => String(c.category_id) === String(stream.category_id))?.category_name || 'Uncategorized',
             sourceId,

--- a/public/js/components/SourceManager.js
+++ b/public/js/components/SourceManager.js
@@ -255,7 +255,22 @@ class SourceManager {
       `;
         }
 
-        return nameField + urlField;
+        const enigmaOptions = type === 'm3u' ? `
+        <div class="form-group">
+            <label class="checkbox-label">
+            <input type="checkbox" id="source-zap-before-streaming" ${source.zapBeforeStreaming ? 'checked' : ''}>
+            Zap before streaming (Enigma2/OpenWebif)
+            </label>
+        </div>
+
+        <div class="form-group">
+            <label for="source-zap-delay">Zap delay (ms)</label>
+            <input type="number" id="source-zap-delay" class="form-input"
+                value="${source.zapDelay || 1500}" min="0" step="100">
+        </div>
+        ` : '';
+
+        return nameField + urlField + enigmaOptions;
     }
 
     /**
@@ -266,6 +281,8 @@ class SourceManager {
         const url = document.getElementById('source-url').value.trim();
         const username = document.getElementById('source-username')?.value.trim() || null;
         const password = document.getElementById('source-password')?.value.trim() || null;
+        const zapBeforeStreaming = document.getElementById('source-zap-before-streaming')?.checked || false;
+        const zapDelay = parseInt(document.getElementById('source-zap-delay')?.value) || 1500;
 
         if (!name || !url) {
             alert('Name and URL are required');
@@ -295,7 +312,7 @@ class SourceManager {
                 }
             }
 
-            await API.sources.create({ type, name, url, username, password });
+            await API.sources.create({ type, name, url, username, password, zapBeforeStreaming, zapDelay });
             document.getElementById('modal').classList.remove('active');
             await this.loadSources();
 
@@ -322,14 +339,17 @@ class SourceManager {
             alert('Name and URL are required');
             return;
         }
-
+        console.log("[updateSource] type:",type);
         try {
             const data = { name, url };
             if (type === 'xtream') {
                 data.username = username;
                 if (password) data.password = password;
             }
-
+            if (type === 'm3u') {
+                data.zapBeforeStreaming = document.getElementById('source-zap-before-streaming')?.checked || false;
+                data.zapDelay = parseInt(document.getElementById('source-zap-delay')?.value) || 1500;
+            }
             await API.sources.update(id, data);
             document.getElementById('modal').classList.remove('active');
             await this.loadSources();

--- a/public/js/components/VideoPlayer.js
+++ b/public/js/components/VideoPlayer.js
@@ -851,6 +851,11 @@ class VideoPlayer {
      * Play a channel
      */
     async play(channel, streamUrl) {
+        
+        if(this.currentChannel != channel && channel?.zapBeforeStreaming){
+            await this.zapBeforeStreaming(channel, streamUrl);
+        }
+
         this.currentChannel = channel;
 
         try {
@@ -917,6 +922,7 @@ class VideoPlayer {
 
                         this.updateTranscodeStatus(statusMode, statusText);
                         const playlistUrl = await this.startTranscodeSession(streamUrl, {
+                            program: channel?.program || null,
                             videoMode,
                             videoCodec: info.video,
                             audioCodec: info.audio,
@@ -961,7 +967,10 @@ class VideoPlayer {
                 const statusMode = this.settings.upscaleEnabled ? 'upscaling' : 'transcoding';
                 console.log(`[Player] ${statusText} enabled. Starting session (encode)...`);
                 this.updateTranscodeStatus(statusMode, statusText);
-                const playlistUrl = await this.startTranscodeSession(streamUrl, { videoMode: 'encode' });
+                const playlistUrl = await this.startTranscodeSession(streamUrl, { 
+                    program: channel?.program || null, 
+                    videoMode: 'encode' 
+                });
                 this.currentUrl = playlistUrl;
 
                 // Load HLS
@@ -1012,7 +1021,7 @@ class VideoPlayer {
                     videoCodec = info.video;
                 } catch (e) { console.warn('Probe failed for force audio, assuming h264'); }
 
-                const playlistUrl = await this.startTranscodeSession(streamUrl, { videoMode: 'copy', videoCodec });
+                const playlistUrl = await this.startTranscodeSession(streamUrl, { program: channel?.program || null, videoMode: 'copy', videoCodec });
                 this.currentUrl = playlistUrl;
 
                 console.log('[Player] Playing transcoded HLS stream:', playlistUrl);
@@ -1564,6 +1573,43 @@ class VideoPlayer {
             this.container.requestFullscreen();
         }
     }
+
+    async zapBeforeStreaming(channel, streamUrl) {
+        if (!channel?.zapBeforeStreaming) return;
+        if (!channel?.streamId || !streamUrl) return;
+
+        const delay = parseInt(channel.zapDelay) || 1500;
+
+        try {
+            const u = new URL(streamUrl);
+            const boxUrl = `${u.protocol}//${u.hostname}`;
+
+            console.log('[ZAP] before streaming:', {
+                channel: channel.name,
+                serviceRef: channel.streamId,
+                boxUrl,
+                delay
+            });
+
+            const res = await fetch('/api/openwebif/zap', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    boxUrl,
+                    serviceRef: channel.streamId
+                })
+            });
+
+            if (!res.ok) {
+                console.warn('[ZAP] backend returned:', res.status);
+            }
+
+            await new Promise(resolve => setTimeout(resolve, delay));
+        } catch (err) {
+            console.warn('[ZAP] failed, continuing stream:', err);
+        }
+    }
+
 }
 
 // Export

--- a/public/js/pages/WatchPage.js
+++ b/public/js/pages/WatchPage.js
@@ -456,6 +456,7 @@ class WatchPage {
 
                     this.updateTranscodeStatus(statusMode, statusText);
                     const playlistUrl = await this.startTranscodeSession(url, {
+                        program: this.content?.program || this.content?.data?.program || null,
                         videoMode,
                         seekOffset: this.resumeTime, // Ensure seekOffset is passed
                         videoCodec: info.video,
@@ -493,6 +494,7 @@ class WatchPage {
             console.log(`[WatchPage] ${statusText} enabled. Starting session (encode)...`);
             this.updateTranscodeStatus(statusMode, statusText);
             const playlistUrl = await this.startTranscodeSession(url, {
+                program: this.content?.program || this.content?.data?.program || null,
                 videoMode: 'encode',
                 seekOffset: this.resumeTime
             });
@@ -515,6 +517,7 @@ class WatchPage {
             } catch (e) { console.warn('Probe failed for force audio, assuming h264'); }
 
             const playlistUrl = await this.startTranscodeSession(url, {
+                program: this.currentChannel?.program || null,
                 videoMode: 'copy',
                 videoCodec,
                 seekOffset: this.resumeTime

--- a/server/db/sqlite.js
+++ b/server/db/sqlite.js
@@ -143,6 +143,13 @@ function initSchema() {
         // Column already exists, ignore
     }
 
+    try {
+        db.exec(`ALTER TABLE playlist_items ADD COLUMN program TEXT`);
+        console.log('[SQLite] Added program column to playlist_items');
+    } catch (e) {
+        // Column already exists, ignore
+    }
+    
     console.log('[SQLite] Schema initialized');
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -180,6 +180,7 @@ app.use('/api/probe', require('./routes/probe'));
 app.use('/api/subtitle', require('./routes/subtitle'));
 app.use('/api/settings', require('./routes/settings'));
 app.use('/api/history', require('./routes/history'));
+app.use('/api/openwebif', require('./routes/openwebif'));
 
 // Version endpoint
 app.get('/api/version', (req, res) => {

--- a/server/routes/openwebif.js
+++ b/server/routes/openwebif.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const router = express.Router();
+
+router.post('/zap', async (req, res) => {
+    const { boxUrl, serviceRef } = req.body;
+
+    if (!boxUrl || !serviceRef) {
+        return res.status(400).json({ error: 'boxUrl and serviceRef are required' });
+    }
+
+    try {
+        const zapUrl = `${boxUrl.replace(/\/$/, '')}/web/zap?sRef=${encodeURIComponent(serviceRef)}`;
+        console.log('[ZAP]', zapUrl);
+
+        const response = await fetch(zapUrl);
+        const text = await response.text();
+
+        res.json({
+            success: response.ok,
+            status: response.status,
+            response: text
+        });
+    } catch (err) {
+        console.error('[ZAP] Failed:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+module.exports = router;

--- a/server/routes/sources.js
+++ b/server/routes/sources.js
@@ -63,7 +63,7 @@ router.get('/:id', async (req, res) => {
 // Create source
 router.post('/', async (req, res) => {
     try {
-        const { type, name, url, username, password } = req.body;
+        const { type, name, url, username, password, zapBeforeStreaming, zapDelay } = req.body;
 
         if (!type || !name || !url) {
             return res.status(400).json({ error: 'Type, name, and URL are required' });
@@ -73,7 +73,7 @@ router.post('/', async (req, res) => {
             return res.status(400).json({ error: 'Invalid source type' });
         }
 
-        const source = await sources.create({ type, name, url, username, password });
+        const source = await sources.create({ type, name, url, username, password, zapBeforeStreaming: zapBeforeStreaming === true, zapDelay: parseInt(zapDelay) || 1500 });
         // Trigger Sync
         syncService.syncSource(source.id).catch(console.error);
         res.status(201).json(source);
@@ -91,12 +91,14 @@ router.put('/:id', async (req, res) => {
             return res.status(404).json({ error: 'Source not found' });
         }
 
-        const { name, url, username, password } = req.body;
+        const { name, url, username, password, zapBeforeStreaming, zapDelay } = req.body;
         const updated = await sources.update(req.params.id, {
             name: name || existing.name,
             url: url || existing.url,
             username: username !== undefined ? username : existing.username,
-            password: password !== undefined ? password : existing.password
+            password: password !== undefined ? password : existing.password,
+            zapBeforeStreaming: zapBeforeStreaming !== undefined ? zapBeforeStreaming === true : existing.zapBeforeStreaming || false,
+            zapDelay: zapDelay !== undefined ? parseInt(zapDelay) || 1500: existing.zapDelay || 1500
         });
         // Trigger Sync (if critical fields changed? safely just trigger it)
         syncService.syncSource(parseInt(req.params.id)).catch(console.error);

--- a/server/routes/transcode.js
+++ b/server/routes/transcode.js
@@ -29,7 +29,7 @@ transcodeSession.startCleanupInterval();
  * Body: { url: string, seekOffset?: number }
  */
 router.post('/session', async (req, res) => {
-    const { url, seekOffset, videoMode, videoCodec, audioCodec, audioChannels } = req.body;
+    const { url, seekOffset, videoMode, videoCodec, audioCodec, audioChannels, program } = req.body;
 
     if (!url) {
         return res.status(400).json({ error: 'URL is required' });
@@ -55,7 +55,8 @@ router.post('/session', async (req, res) => {
             videoMode: videoMode, // 'copy' or 'encode'
             videoCodec: videoCodec, // 'h264', 'hevc', etc.
             audioCodec: audioCodec, // 'aac', 'ac3', etc.
-            audioChannels: audioChannels // number of channels (2=stereo)
+            audioChannels: audioChannels, // number of channels (2=stereo)
+            program: program || null
         });
 
         await session.start();

--- a/server/services/m3uParser.js
+++ b/server/services/m3uParser.js
@@ -88,6 +88,7 @@ async function parse(input) {
     const groupsSet = new Set();
     let currentInfo = null;
     let currentGroup = null;
+    let currentVlcProgram = null;
 
     let lines;
 
@@ -121,6 +122,11 @@ async function parse(input) {
             if (currentInfo) {
                 currentInfo.groupTitle = currentGroup;
             }
+        } else if (trimmed.startsWith('#EXTVLCOPT:program=')) {
+            currentVlcProgram = trimmed.split('=')[1]?.trim() || null;
+            if (currentInfo) {
+                currentInfo.program = currentVlcProgram;
+            }
         } else if (!trimmed.startsWith('#')) {
             // This is a stream URL
             if (currentInfo) {
@@ -132,9 +138,11 @@ async function parse(input) {
                     ...currentInfo,
                     id: stableId,
                     url: trimmed,
+                    program: currentVlcProgram,
                     groupTitle: groupTitle
                 });
                 currentInfo = null;
+                currentVlcProgram = null;
             }
         }
     }
@@ -216,6 +224,11 @@ async function* parseStreaming(input, batchSize = 500) {
             if (currentInfo) {
                 currentInfo.groupTitle = currentGroup;
             }
+        } else if (trimmed.startsWith('#EXTVLCOPT:program=')) {
+            currentVlcProgram = trimmed.split('=')[1]?.trim() || null;
+            if (currentInfo) {
+                currentInfo.program = currentVlcProgram;
+            }
         } else if (!trimmed.startsWith('#')) {
             if (currentInfo) {
                 const groupTitle = currentInfo.groupTitle || currentGroup || 'Uncategorized';
@@ -225,9 +238,11 @@ async function* parseStreaming(input, batchSize = 500) {
                     ...currentInfo,
                     id: stableId,
                     url: trimmed,
+                    program: currentVlcProgram,
                     groupTitle: groupTitle
                 });
                 currentInfo = null;
+                currentVlcProgram = null;
 
                 // Yield batch when full
                 if (batch.length >= batchSize) {

--- a/server/services/m3uXtreamAdapter.js
+++ b/server/services/m3uXtreamAdapter.js
@@ -58,6 +58,7 @@ class M3uXtreamAdapter {
                 name,
                 stream_icon,
                 stream_url,
+                program,
                 category_id,
                 added_at,
                 data
@@ -92,6 +93,7 @@ class M3uXtreamAdapter {
                 added: row.added_at,
                 // M3U-specific: direct stream URL (Xtream builds URLs from credentials)
                 stream_url: row.stream_url,
+                program: row.program || extra.program || null,
                 // Include extra fields from parser (tvgId, etc.)
                 epg_channel_id: extra.tvgId || null,
                 ...extra

--- a/server/services/syncService.js
+++ b/server/services/syncService.js
@@ -270,14 +270,16 @@ class SyncService {
         const stmt = db.prepare(`
             INSERT INTO playlist_items (
                 id, source_id, item_id, type, name, category_id, 
-                stream_icon, stream_url, container_extension, 
+                stream_icon, stream_url,program, container_extension, 
                 rating, year, added_at, data
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
                 category_id = excluded.category_id,
                 stream_icon = excluded.stream_icon,
+                stream_url = excluded.stream_url,
+                program = excluded.program,
                 container_extension = excluded.container_extension,
                 data = excluded.data
         `);
@@ -324,6 +326,7 @@ class SyncService {
                     String(catId),
                     icon,
                     null, // Direct URL not stored for Xtream usually, built on fly
+                    item.program || null,
                     container,
                     rating,
                     year,
@@ -459,9 +462,9 @@ class SyncService {
             const channelStmt = db.prepare(`
                 INSERT INTO playlist_items (
                     id, source_id, item_id, type, name, stream_icon, 
-                    stream_url, category_id, data
+                    stream_url, program, category_id, data
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
                     stream_icon = excluded.stream_icon,
@@ -478,8 +481,9 @@ class SyncService {
                         'epg_channel',
                         ch.name,
                         ch.icon || null,
-                        null,
-                        null,
+                        null,   // stream_url
+                        null,   // program
+                        null,   // category_id
                         JSON.stringify(ch)
                     );
                 }
@@ -524,6 +528,7 @@ class SyncService {
                 stream_icon: ch.tvgLogo,
                 stream_url: ch.url,
                 tvgId: ch.tvgId || null,
+                program: ch.program || null,
             }));
 
             // Save this batch immediately (skip purge - we'll do it at the end)

--- a/server/services/transcodeSession.js
+++ b/server/services/transcodeSession.js
@@ -211,8 +211,12 @@ class TranscodeSession extends EventEmitter {
         }
 
         // Map streams
-        args.push('-map', '0:v:0');
-        args.push('-map', '0:a:0?');
+       if (this.options.program) {
+            args.push('-map', `p:${this.options.program}`);
+        } else {
+            args.push('-map', '0:v:0');
+            args.push('-map', '0:a:0?');
+        }
 
         // Add video encoder and filters based on selected encoder OR copy
         if (videoMode === 'copy') {


### PR DESCRIPTION
# Add Enigma2/OpenWebif M3U support with program mapping and optional zap-before-streaming

## Summary

This PR improves support for Enigma2/OpenWebif-style M3U playlists and MPEG-TS streams.

Some Enigma2/OpenWebif playlists include VLC-specific metadata such as:

```m3u
#EXTVLCOPT:program=1234
```

This value identifies the MPEG-TS program that should be selected by the player. Without preserving and passing this metadata to FFmpeg, some multi-program TS streams may be probed incorrectly or mapped to the wrong video/audio streams.

This PR also adds an optional per-M3U-source "Zap before streaming" setting for Enigma2/OpenWebif sources.

## Changes

* Parse and preserve `#EXTVLCOPT:program` from M3U playlists.
* Store the parsed program ID in channel metadata.
* Propagate the program ID through the M3U adapter and frontend channel objects.
* Pass the program ID to FFmpeg using:

```bash
-map p:<program>
```

* Add optional per-source M3U settings:

  * `zapBeforeStreaming`
  * `zapDelay`
* Add an OpenWebif zap proxy endpoint.
* Trigger a zap operation before playback when enabled for a source.
* Preserve backward compatibility for standard M3U and Xtream sources.

## Why

Browser playback and FFmpeg probing can fail or select the wrong streams when an MPEG-TS input contains multiple programs or requires explicit program selection.

OpenWebif-generated playlists already provide the required program metadata via `#EXTVLCOPT:program`, but NodeCast previously ignored it.

This resulted in some streams failing to play or FFmpeg selecting incorrect video/audio streams.

## Technical Details

### M3U Parsing

The M3U parser now extracts and preserves:

```m3u
#EXTVLCOPT:program=1234
```

and stores the value as:

```json
{
  "program": "1234"
}
```

### Data Flow

The program metadata is now propagated through:

1. M3U parser
2. Synchronization service
3. Database storage
4. M3U adapter
5. Frontend channel objects
6. Playback/transcoding pipeline

### FFmpeg Program Selection

When a program ID is available, FFmpeg is instructed to select the corresponding MPEG-TS program:

```bash
-map p:<program>
```

instead of relying solely on:

```bash
-map 0:v:0
-map 0:a:0?
```

This improves compatibility with multi-program transport streams.

### Zap Before Streaming

A new optional source-level configuration has been added:

```json
{
  "zapBeforeStreaming": true,
  "zapDelay": 1500
}
```

When enabled:

1. The player requests a zap operation through OpenWebif.
2. Waits for the configured delay.
3. Starts probing/transcoding/playback.

This is particularly useful for tuner-based Enigma2/OpenWebif sources where the stream may not be immediately available after a channel change.

## Testing

Tested with:

* OpenWebif-generated M3U playlists.
* MPEG-TS streams served through Enigma2 streaming endpoints.
* Software transcoding (HLS).
* Program-specific FFmpeg mapping using `-map p:<program>`.
* Zap-before-streaming enabled and disabled.
* Existing M3U import workflows.
* Existing XMLTV EPG import workflows.

No provider-specific assumptions are required.

## Compatibility

* Existing M3U playlists without `#EXTVLCOPT:program` continue to use the existing default mapping:

```bash
-map 0:v:0
-map 0:a:0?
```

* Zap-before-streaming is disabled by default.
* Existing Xtream sources are unaffected.
* Existing M3U sources are unaffected unless the new option is explicitly enabled.
