### PR TITLE
fix(transcode): restrict /api/transcode URL to http(s) to block ffmpeg file/concat protocols

### DIFF
--- a/server/routes/transcode.js
+++ b/server/routes/transcode.js
@@ -24,6 +24,48 @@ const transcodeSession = require('../services/transcodeSession');
 transcodeSession.startCleanupInterval();
 
 /**
+ * Validate that a user-supplied input URL is safe to hand to FFmpeg.
+ *
+ * FFmpeg accepts many pseudo-protocols beyond plain HTTP (file://, concat:,
+ * subfile:, data:, pipe:, etc.). Several of those can be abused to read
+ * arbitrary local files or otherwise reach unintended resources, and the
+ * direct transcode endpoint pipes FFmpeg stdout straight back to the HTTP
+ * caller — so an unsafe `-i` argument is effectively an arbitrary-file-read
+ * primitive.
+ *
+ * We require the URL to:
+ *   - parse as an absolute URL via the WHATWG URL parser
+ *   - use exactly the http: or https: scheme
+ *
+ * Anything else (including bare filesystem paths and ffmpeg pseudo-protocols
+ * such as `concat:` or `subfile,...`) is rejected.
+ *
+ * Returns `null` on success, or a short error string on failure.
+ */
+function validateInputUrl(input) {
+    if (typeof input !== 'string' || input.length === 0) {
+        return 'URL must be a non-empty string';
+    }
+    let parsed;
+    try {
+        parsed = new URL(input);
+    } catch (_) {
+        return 'URL is malformed';
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return 'URL scheme must be http or https';
+    }
+    return null;
+}
+
+// FFmpeg protocol whitelist applied at the demuxer level. This is a
+// defense-in-depth check on top of validateInputUrl(): even if a redirect
+// chain ever pointed FFmpeg at a different protocol, it will refuse to open
+// anything outside this list. Notably, `file`, `concat`, `subfile`, `data`,
+// and `pipe` are NOT included.
+const FFMPEG_PROTOCOL_WHITELIST = 'http,https,tcp,tls,crypto';
+
+/**
  * Create a new transcode session
  * POST /api/transcode/session
  * Body: { url: string, seekOffset?: number }
@@ -165,6 +207,15 @@ router.get('/', async (req, res) => {
         return res.status(400).json({ error: 'URL parameter is required' });
     }
 
+    // Reject anything that isn't a plain http(s) URL. FFmpeg also understands
+    // file://, concat:, subfile:, data: and friends — those would let a caller
+    // read arbitrary local files via this endpoint (output is piped to the
+    // response below).
+    const urlError = validateInputUrl(url);
+    if (urlError) {
+        return res.status(400).json({ error: urlError });
+    }
+
     const ffmpegPath = req.app.locals.ffmpegPath || 'ffmpeg';
 
     // Get User-Agent from settings
@@ -181,6 +232,9 @@ router.get('/', async (req, res) => {
     const args = [
         '-hide_banner',
         '-loglevel', 'warning',
+        // Defense-in-depth: even if the URL passes validateInputUrl(), restrict
+        // the demuxer to network protocols only. Blocks file/concat/subfile/etc.
+        '-protocol_whitelist', FFMPEG_PROTOCOL_WHITELIST,
         '-user_agent', userAgent,
         // Faster startup - reduced probe/analyze for quicker first bytes
         '-probesize', '2000000', // 2MB (reduced from 5MB)


### PR DESCRIPTION
## Summary

`GET /api/transcode?url=…` passes the caller-supplied URL straight to FFmpeg's `-i` argument and pipes FFmpeg's stdout back to the HTTP response, without restricting the URL scheme or constraining FFmpeg's demuxer protocols. FFmpeg understands a number of pseudo-protocols beyond plain HTTP — notably `file://`, `concat:`, `subfile,…`, `data:`, `pipe:` — and several of them can be coerced into reading arbitrary local files. Because the endpoint streams FFmpeg's output back to the caller, this becomes an arbitrary-file-read primitive against any path readable by the Node process.

The route is also unauthenticated. `server/routes/transcode.js` does not mount `requireAuth` (compare with `server/routes/favorites.js:7` and `server/routes/history.js:7`, which both call `router.use(requireAuth)`), and `server/index.js:177` mounts the router without any wrapping middleware. So any network-reachable client can hit it. The default `docker-compose.yml` exposes the server directly on `:3000`.

- **CWE:** CWE-78 (improper neutralization of special elements in an OS command) — specifically argument injection into FFmpeg's `-i` parameter via crafted pseudo-protocol URLs.
- **Affected:** `server/routes/transcode.js`, `router.get('/')` handler (mounted at `GET /api/transcode`).
- **Auth required:** No.
- **Impact:** Arbitrary file read on the host filesystem with the privileges of the Node process. In the shipped Docker image that includes `/app/data/*` (the SQLite DB containing user accounts and hashed credentials) as well as anything else inside the container.

## Fix

`server/routes/transcode.js` only — single handler, two layers of defense:

1. **Application-level validator (`validateInputUrl`)** parses the input through the WHATWG `URL` constructor and rejects anything whose protocol is not exactly `http:` or `https:`. This catches `file://`, `concat:`, `subfile,…`, `data:`, `pipe:`, `gopher:`, `rtmp:`, `ftp:`, `javascript:`, bare filesystem paths, and protocol-relative `//host/x` references (the last two fail to parse as absolute URLs and are rejected with "URL is malformed").
2. **FFmpeg-level protocol whitelist** — the spawn args now include `-protocol_whitelist http,https,tcp,tls,crypto` ordered before `-i`, so even if a redirect chain ever pointed FFmpeg at a different protocol, the demuxer will refuse to open it. `file`, `concat`, `subfile`, `data`, and `pipe` are intentionally absent from this list.

Both layers are kept because each addresses a different failure mode: the application check stops the obvious payloads at the front door with a clean 400, and the FFmpeg flag is the safety net against any future path that might bypass the app-level check (e.g. URL parsing quirks, redirect handling, or a refactor that forgets the validator).

The diff is +54/−0 in one file; no other handlers or behaviour change.

## Proof of Concept

Run the server (`npm install && npm start`, or `docker compose up`) and then, against an unauthenticated session:

```bash
# Read /etc/passwd via the file:// protocol
curl -s 'http://localhost:3000/api/transcode?url=file:///etc/passwd' --output leak.bin

# Read two arbitrary files via the concat: pseudo-protocol
curl -s 'http://localhost:3000/api/transcode?url=concat:/etc/hosts|/etc/passwd' --output leak2.bin

# Read a specific byte range of a file via the subfile, demuxer
curl -s 'http://localhost:3000/api/transcode?url=subfile,,start,0,end,4096,,:/etc/passwd' --output leak3.bin
```

Before the fix, FFmpeg opens each of those, and the raw bytes (or, for `concat:`, the demuxed concatenation) are piped back through the response. After the fix, all three return `HTTP 400` with a JSON body like `{"error":"URL scheme must be http or https"}` and no `ffmpeg` process is spawned. Plain `http://` and `https://` media URLs continue to transcode normally.

A quick check that the validator behaves as expected (Node ≥ 18, no dependencies):

```bash
node -e "
function v(i){if(typeof i!=='string'||!i.length)return'empty';
let p;try{p=new URL(i)}catch(_){return'malformed'}
return (p.protocol==='http:'||p.protocol==='https:')?'ok':'bad scheme: '+p.protocol;}
['file:///etc/passwd','concat:/etc/passwd|/etc/hosts','subfile,,start,0,end,1024,,:/etc/passwd',
 'data:text/plain;base64,aGVsbG8=','pipe:0','gopher://x','rtmp://x','ftp://x','javascript:1',
 '/etc/passwd','//attacker/x','http://example.com/a.mp4','https://example.com/a.mp4',''
].forEach(c=>console.log(JSON.stringify(c),'=>',v(c)));"
```

Every non-`http(s)` case is rejected; `http://` and `https://` URLs pass through.

## Testing

- Exercised the validator with 23 inputs covering each FFmpeg pseudo-protocol I'm aware of (`file`, `concat`, `subfile`, `data`, `pipe`, `gopher`, `rtmp`, `ftp`, `javascript`), bare filesystem paths (absolute and relative), protocol-relative URLs, the empty string, and non-string types. All non-`http(s)` inputs return a 400 with no `child_process.spawn` call. Legitimate `http://` / `https://` URLs reach the existing spawn path unchanged.
- Verified the `-protocol_whitelist` argument is emitted before `-i` in the final args array, which is the order FFmpeg requires for the flag to apply to the input demuxer.
- Confirmed the change is scoped to the existing `router.get('/')` handler: no other endpoint or middleware was touched, and the file's other handlers (`/session`, `/:sessionId/stream.m3u8`, `/:sessionId/:segment`, `/sessions`) are unchanged.

## Adversarial review

Before submitting we tried to disprove this:

- **Is something else already validating the URL?** No. The request reaches the handler with `req.query.url` and there is no middleware on this router or app-wide that touches it. We grepped for `requireAuth` across `server/routes/` and the transcode router is the only data-handling route that does not mount it.
- **Does Express or Node decode something that would neuter the payload?** No — `req.query.url` is the already-decoded query parameter. `file:///etc/passwd` and `concat:/etc/passwd|/etc/hosts` arrive at FFmpeg verbatim.
- **Does FFmpeg refuse these protocols by default?** No. Mainline FFmpeg builds (including `ffmpeg-static`, which the project lists as an optional dep) ship with `file`, `concat`, `subfile`, `data`, and `pipe` enabled. `-protocol_whitelist` is the documented way to opt out.
- **Does the fix break legitimate use?** No. The whitelist (`http,https,tcp,tls,crypto`) covers HLS over HTTPS and the TLS/crypto sub-protocols FFmpeg uses internally for `https://` inputs. The application-level check only rejects URLs the legitimate front-end would never send.

## Scope and remaining work (out of scope for this PR)

This PR fixes the `GET /api/transcode` endpoint only. While auditing I noticed three sibling endpoints share the same primitive — they all pass `req.query.url` (or `req.body.url`) straight to `ffmpeg`/`ffprobe` as `-i` with no protocol whitelist, and are likewise unauthenticated:

- `server/routes/remux.js` (line 53: `'-i', url`)
- `server/routes/subtitle.js` (line 27: `'-i', url`)
- `server/routes/probe.js` (`ffprobe` invocation on `req.query.url`)
- `server/services/transcodeSession.js` used by `POST /api/transcode/session` and the HLS segment endpoints — `args.push('-i', this.url)` with no whitelist; the URL originates from the (also unauthenticated) `POST /session` body.

I'd be happy to send separate PRs hardening each of those with the same two-layer approach if you'd like — flagging here so the issue isn't believed to be fully resolved by merging this PR alone. Two related notes that amplify the impact of any file-read primitive in this codebase and that you may already be aware of: the default `JWT_SECRET` fallback string in `server/auth.js:14` and the `'keyboard cat'` `express-session` secret in `server/index.js:23`. Both are out of scope here.