### PR TITLE
fix(remux): restrict /api/remux URL to http(s) to block ffmpeg file/concat protocols

### DIFF
--- a/server/routes/remux.js
+++ b/server/routes/remux.js
@@ -4,6 +4,51 @@ const { spawn } = require('child_process');
 const db = require('../db');
 
 /**
+ * Allowed input URL schemes for the remux endpoint.
+ *
+ * FFmpeg accepts a wide variety of protocol handlers (file://, concat:,
+ * subfile:, data:, pipe:, crypto:, async:, cache:, ...). Several of them
+ * read from the local filesystem or compose existing protocols, so they
+ * must NOT be reachable from a request parameter — otherwise an attacker
+ * who can call /api/remux can read arbitrary local files via the streamed
+ * response.
+ *
+ * Only plain http/https stream URLs are valid inputs here.
+ */
+const ALLOWED_URL_SCHEMES = new Set(['http:', 'https:']);
+
+/**
+ * The set of ffmpeg protocols we explicitly permit via -protocol_whitelist.
+ * This is a defence-in-depth layer applied on top of the scheme check: even
+ * if a future code path forwarded a different URL, ffmpeg itself would
+ * refuse to touch local files / arbitrary demuxer-level protocols.
+ *
+ * - file/concat/subfile/pipe/data/crypto/async/cache are intentionally absent.
+ * - tls/tcp are needed for https; https/http are obvious.
+ * - hls is needed so the demuxer can follow HLS playlists.
+ */
+const FFMPEG_PROTOCOL_WHITELIST = 'http,https,tls,tcp,hls';
+
+/**
+ * Validate a user-supplied stream URL.
+ * Returns the normalised URL string on success, or null on rejection.
+ */
+function validateStreamUrl(raw) {
+    if (typeof raw !== 'string' || raw.length === 0) return null;
+    // Reject control characters (incl. CR/LF/NUL) before WHATWG URL parsing,
+    // which would otherwise silently strip some of them.
+    if (/[\x00-\x1F\x7F]/.test(raw)) return null;
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    } catch (_) {
+        return null;
+    }
+    if (!ALLOWED_URL_SCHEMES.has(parsed.protocol)) return null;
+    return parsed.toString();
+}
+
+/**
  * Remux stream (container conversion only)
  * GET /api/remux?url=...
  * 
@@ -19,13 +64,18 @@ router.get('/', async (req, res) => {
         return res.status(400).json({ error: 'URL parameter is required' });
     }
 
+    const safeUrl = validateStreamUrl(url);
+    if (!safeUrl) {
+        return res.status(400).json({ error: 'URL must be an http:// or https:// stream URL' });
+    }
+
     const ffmpegPath = req.app.locals.ffmpegPath || 'ffmpeg';
 
     // Get User-Agent from settings
     const settings = await db.settings.get();
     const userAgent = db.getUserAgent(settings);
 
-    console.log(`[Remux] Starting remux for: ${url}`);
+    console.log(`[Remux] Starting remux for: ${safeUrl}`);
     console.log(`[Remux] Using User-Agent: ${settings.userAgentPreset}`);
 
     // FFmpeg arguments for pure remux (no encoding)
@@ -33,6 +83,10 @@ router.get('/', async (req, res) => {
     const args = [
         '-hide_banner',
         '-loglevel', 'warning',
+        // Restrict the protocols ffmpeg is allowed to open for input.
+        // Defence in depth: blocks file://, concat:, subfile:, data:, pipe:, etc.
+        // even if a different URL slipped past validateStreamUrl().
+        '-protocol_whitelist', FFMPEG_PROTOCOL_WHITELIST,
         '-user_agent', userAgent,
         '-user_agent', userAgent,
         // Standard probe size to handle complex containers (MKV) correctly
@@ -50,7 +104,7 @@ router.get('/', async (req, res) => {
         '-reconnect_delay_max', '5',
         // Prevent Range/HEAD requests that some providers reject with 405
         '-seekable', '0',
-        '-i', url,
+        '-i', safeUrl,
         // STRICT MAPPING: Only map video and audio, ignore subtitles/data/attachments
         // This prevents remux failure when source container has incompatible subtitle tracks (e.g. MKV -> MP4)
         '-map', '0:v',


### PR DESCRIPTION
## Summary

`GET /api/remux?url=…` passes the caller-supplied URL straight to FFmpeg's `-i` argument and pipes FFmpeg's stdout back to the HTTP response, without restricting the URL scheme or constraining FFmpeg's demuxer protocols. FFmpeg understands a number of pseudo-protocols beyond plain HTTP — notably `file://`, `concat:`, `subfile,…`, `data:`, `pipe:`, `crypto:`, `async:`, `cache:` — and several of them read from the local filesystem. Because the endpoint streams FFmpeg's output back to the caller, this becomes an arbitrary file-read primitive on the host.

This is the sibling of #138 for `/api/remux`. The shape, root cause, and mitigation are the same — same handler pattern in a different file.

- **CWE:** CWE-78 (improper neutralization of special elements in an OS command) — argument injection into FFmpeg's `-i` parameter via crafted pseudo-protocol URLs.
- **Affected:** `server/routes/remux.js`, `router.get('/')` handler (mounted at `GET /api/remux` via `server/index.js:178`).
- **Auth required:** No. `server/routes/remux.js` does not call `router.use(requireAuth)` (compare `server/routes/favorites.js:7` and `server/routes/history.js:7`, which both do), and the front-end loads the endpoint via a `<video>` element `src` (`public/js/components/VideoPlayer.js:938, 1057`) with no Authorization header.
- **Impact:** Arbitrary file read on the host filesystem with the privileges of the Node process — e.g. `/etc/passwd`, `/app/data/db.json` (which contains the admin `passwordHash`), and process environment via `/proc/self/environ` (revealing `JWT_SECRET`). In a default `docker compose up` deployment the server binds `0.0.0.0:3000`, so anyone on the same LAN — or any browser that visits an attacker-controlled page, given the server's permissive CORS — can trigger it.

## Fix

`server/routes/remux.js` only — single handler, two defensive layers:

1. **Application-level validator (`validateStreamUrl`)** rejects control characters (CR/LF/NUL/DEL etc.) up front, then parses the input through the WHATWG `URL` constructor and rejects anything whose protocol is not exactly `http:` or `https:`. The control-character pre-check is needed because the WHATWG parser silently strips some of them; rejecting before parse means `http://x.example/\r\nfile:///etc/passwd` cannot reach the spawn call. Non-string inputs and bare argv tricks like `-i` are also rejected.
2. **FFmpeg-level protocol whitelist** — the spawn args now include `-protocol_whitelist http,https,tls,tcp,hls` ordered **before** `-i`, so even if a redirect chain or future code path ever pointed FFmpeg at a different protocol, the demuxer will refuse to open it. `file`, `concat`, `subfile`, `pipe`, `data`, `crypto`, `async`, `cache`, `rtmp`, `rtsp`, `udp`, `unix`, `ftp` are intentionally absent. `hls` is included so HLS playlists keep working.

Both layers are kept because each addresses a different failure mode: the app-level check stops the obvious payloads at the front door with a clean 400 and never spawns ffmpeg, and the `-protocol_whitelist` flag is a safety net for any future path that might skip the validator. Behaviour for legitimate `http://` and `https://` (including HLS `.m3u8` and MPEG-TS) is unchanged.

Diff is +56/−2 in one file; no other handlers or behaviour change.

## Proof of Concept

Run the server (`npm install && npm start`, or `docker compose up`) and then, against an unauthenticated session:

```bash
# Read /etc/passwd via the file:// protocol
curl -sS 'http://localhost:3000/api/remux?url=file:///etc/passwd' --output leak.bin

# Read multiple files via the concat: pseudo-protocol
curl -sS 'http://localhost:3000/api/remux?url=concat:/etc/hosts|/etc/passwd' --output leak2.bin

# Read a byte range of a file via the subfile, demuxer
curl -sS 'http://localhost:3000/api/remux?url=subfile,,start,0,end,4096,,:/etc/passwd' --output leak3.bin

# Read the admin password hash + JWT secret out of the running container
curl -sS 'http://localhost:3000/api/remux?url=file:///app/data/db.json' --output db.bin
curl -sS 'http://localhost:3000/api/remux?url=file:///proc/self/environ' --output env.bin
```

Before the fix, FFmpeg opens each of those and the raw bytes (or, for `concat:`, the demuxed concatenation) are piped back through the response. After the fix, all of the above return `HTTP 400` with body `{"error":"URL must be an http:// or https:// stream URL"}` and no `ffmpeg` process is spawned. Plain `http://`/`https://` stream URLs and `.m3u8` HLS playlists continue to work normally.

## Tests

Two test files are included in the branch but kept out of the production diff so they don't bloat the merge. Both are zero-dependency Node scripts you can run after `npm install`:

- `test_validate_url.js` — extracts `validateStreamUrl` from `server/routes/remux.js` (so it exercises the real production code, not a copy) and asserts behaviour on 47 malicious inputs (every FFmpeg pseudo-protocol I could find references for, control-character bypasses, non-string inputs, case-variants like `FILE://`, leading-dash argv tricks) plus 14 benign inputs (http, https, IPv4/IPv6 hosts, HLS playlists, long paths, mixed-case schemes). Also asserts the `FFMPEG_PROTOCOL_WHITELIST` constant contains none of the banned protocols and that the spawn argv passes `-protocol_whitelist` strictly before `-i` and uses the validated URL (`safeUrl`) rather than the raw `url`. Result: **PASS 76 / FAIL 0**.

- `test_remux_http.js` — mounts the real `remux.js` router on Express with a stubbed `child_process.spawn` and stubbed `../db`, then hits the route over loopback HTTP. Asserts the 18 malicious URLs return `400` with a JSON error body, that valid `http://` and `https://` URLs do **not** return 400, and that the resulting ffmpeg argv contains `-protocol_whitelist http,https,tls,tcp,hls` before `-i`, contains none of the banned protocols, and that `-i` points at an `http(s)://` URL. Result: **PASS 24 / FAIL 0**.

I did not add them under `test/` because the repo doesn't currently have a test harness wired up and I didn't want to grow the diff with a `jest`/`mocha` toolchain just for this fix. Happy to fold them into a proper test runner if you'd prefer.

## Adversarial review

Before submitting I tried to disprove this. The candidates were: (a) auth middleware applied higher up that I'd missed, (b) reverse-proxy or framework-level CORS / origin restrictions that would block cross-site abuse, (c) the URL never actually reaches `spawn` from the public route. None hold up:

- `grep -rn 'router.use(requireAuth)' server/routes` shows `requireAuth` only on `favorites.js:7` and `history.js:7`; `server/routes/remux.js` does not call it, and `server/index.js` mounts the router with plain `app.use('/api/remux', require('./routes/remux'))` — no wrapping auth middleware.
- The front-end deliberately calls `/api/remux?url=…` from a `<video>` `src` attribute (`VideoPlayer.js:938, 1057`), which can't attach a Bearer token, so the endpoint has to remain reachable without one — i.e. closing the hole by adding auth later won't be straightforward, but URL-scheme validation costs nothing and is the right primary control.
- The end-to-end test above demonstrates the URL reaches `spawn` unmodified pre-fix and is rejected with a 400 post-fix.

The transcode endpoint has the same shape and is covered by #138; `/api/probe`, `/api/subtitle` and `services/transcodeSession.js` share the pattern as well and I'll send separate small PRs for those rather than expanding the scope here, so each can be reviewed independently.