### PR TITLE
perf: cut Live TV load time from ~10s to <1s on large providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@ffprobe-installer/ffprobe": "^2.1.2",
                 "bcryptjs": "^3.0.3",
                 "better-sqlite3": "^12.5.0",
+                "compression": "^1.8.1",
                 "dotenv": "^17.2.3",
                 "express": "^4.18.2",
                 "express-session": "^1.18.2",
@@ -413,6 +414,45 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "license": "ISC"
+        },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
+                "debug": "2.6.9",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/concat-stream": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@ffprobe-installer/ffprobe": "^2.1.2",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.5.0",
+        "compression": "^1.8.1",
         "dotenv": "^17.2.3",
         "express": "^4.18.2",
         "express-session": "^1.18.2",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -150,11 +150,18 @@ class App {
         // Initialize home page first (it's needed for channel list)
         await this.pages.home.init();
 
-        // Preload EPG data in background (non-blocking)
-        // This ensures EPG info is available on Live TV page without visiting Guide first
-        this.epgGuide.loadEpg().catch(err => {
-            console.warn('Background EPG load failed:', err.message);
-        });
+        // Preload only the currently-airing programme per channel (non-blocking), so
+        // the Live TV sidebar has "what's on now" without visiting Guide first.
+        // The full +/-24h guide is loaded lazily by GuidePage.show().
+        this.epgGuide.fetchNowPlaying()
+            .then(() => {
+                this.channelList.clearProgramInfoCache();
+                this.channelList.updateVisibleEpgInfo?.();
+                this.epgGuide.startBackgroundRefresh();
+            })
+            .catch(err => {
+                console.warn('Background EPG load failed:', err.message);
+            });
 
         // Navigate to the page from URL hash, or default to home
         const hash = window.location.hash.slice(1); // Remove #

--- a/public/js/components/ChannelList.js
+++ b/public/js/components/ChannelList.js
@@ -753,18 +753,23 @@ class ChannelList {
             const m3uSources = this.sources.filter(s => s.type === 'm3u' && s.enabled);
             console.log('[ChannelList] loadAllChannels: xtream=', xtreamSources.length, 'm3u=', m3uSources.length);
 
-            for (const source of xtreamSources) {
-                await this.loadXtreamChannels(source.id, true);
-            }
+            // Fetch every source concurrently, then apply in a fixed order (xtream
+            // before m3u, source order within each) so the rendered list is stable
+            // regardless of which provider responds first.
+            const pending = [
+                ...xtreamSources.map(s => this.fetchSourceChannels(s.id, 'xtream')),
+                ...m3uSources.map(s => this.fetchSourceChannels(s.id, 'm3u'))
+            ];
 
-            for (const source of m3uSources) {
-                await this.loadM3uChannels(source.id, true);
-            }
-
-            await Promise.all([
+            const [loaded] = await Promise.all([
+                Promise.all(pending),
                 this.loadHiddenItems(),
                 this.loadFavorites()
             ]);
+
+            for (const result of loaded) {
+                this._applySourceChannels(result, true);
+            }
             this.render();
         } catch (err) {
             console.error('Error loading all channels:', err);
@@ -775,39 +780,7 @@ class ChannelList {
      * Load Xtream channels
      */
     async loadXtreamChannels(sourceId, append = false) {
-        if (!append) {
-            this.channels = [];
-            this.groups = [];
-        }
-
-        const categories = await API.proxy.xtream.liveCategories(sourceId);
-        const streams = await API.proxy.xtream.liveStreams(sourceId);
-
-        // Map categories to groups
-        const categoryGroups = categories.map(cat => ({
-            id: `xtream_${sourceId}_${cat.category_id}`,
-            name: cat.category_name,
-            sourceId,
-            sourceType: 'xtream'
-        }));
-
-        this.groups = this.groups.concat(categoryGroups);
-
-        // Map streams to channels
-        const channelList = streams.map(stream => ({
-            id: `xtream_${sourceId}_${stream.stream_id}`,
-            streamId: stream.stream_id,
-            name: stream.name,
-            tvgId: stream.epg_channel_id,
-            tvgLogo: stream.stream_icon,
-            groupId: `xtream_${sourceId}_${stream.category_id}`,
-            // Use string comparison to handle type mismatches (number vs string category_id)
-            groupTitle: categories.find(c => String(c.category_id) === String(stream.category_id))?.category_name || 'Uncategorized',
-            sourceId,
-            sourceType: 'xtream'
-        }));
-
-        this.channels = this.channels.concat(channelList);
+        this._applySourceChannels(await this.fetchSourceChannels(sourceId, 'xtream'), append);
     }
 
     /**
@@ -815,40 +788,64 @@ class ChannelList {
      * Now uses unified Xtream-style API endpoints (backend supports both source types)
      */
     async loadM3uChannels(sourceId, append = false) {
+        this._applySourceChannels(await this.fetchSourceChannels(sourceId, 'm3u'), append);
+    }
+
+    /**
+     * Fetch and map one source's categories + streams. Pure: returns the mapped
+     * groups/channels rather than mutating, so callers can fetch several sources
+     * concurrently and still apply them in a stable order.
+     */
+    async fetchSourceChannels(sourceId, sourceType) {
+        // Both endpoints are independent; serialising them doubled the round trips.
+        const [categories, streams] = await Promise.all([
+            API.proxy.xtream.liveCategories(sourceId),
+            API.proxy.xtream.liveStreams(sourceId)
+        ]);
+
+        const prefix = `${sourceType}_${sourceId}`;
+
+        const groups = categories.map(cat => ({
+            id: `${prefix}_${cat.category_id}`,
+            name: cat.category_name,
+            sourceId,
+            sourceType
+        }));
+
+        // Was categories.find() inside this map - O(streams x categories), which on a
+        // large provider is millions of string comparisons per source.
+        // Use string keys to handle type mismatches (number vs string category_id).
+        const categoryNames = new Map(
+            categories.map(c => [String(c.category_id), c.category_name])
+        );
+
+        const channels = streams.map(stream => {
+            const channel = {
+                id: `${prefix}_${stream.stream_id}`,
+                streamId: stream.stream_id,
+                name: stream.name,
+                tvgId: stream.epg_channel_id,
+                tvgLogo: stream.stream_icon,
+                groupId: `${prefix}_${stream.category_id}`,
+                groupTitle: categoryNames.get(String(stream.category_id)) || 'Uncategorized',
+                sourceId,
+                sourceType
+            };
+            // M3U has direct URLs; Xtream builds them server-side.
+            if (sourceType === 'm3u') channel.url = stream.stream_url;
+            return channel;
+        });
+
+        return { groups, channels };
+    }
+
+    _applySourceChannels({ groups, channels }, append) {
         if (!append) {
             this.channels = [];
             this.groups = [];
         }
-
-        // Use Xtream API endpoints - backend now supports M3U sources too
-        const categories = await API.proxy.xtream.liveCategories(sourceId);
-        const streams = await API.proxy.xtream.liveStreams(sourceId);
-
-        // Map categories to groups (keeping m3u sourceType for downstream compatibility)
-        const m3uGroups = categories.map(cat => ({
-            id: `m3u_${sourceId}_${cat.category_id}`,
-            name: cat.category_name,
-            sourceId,
-            sourceType: 'm3u'
-        }));
-
-        this.groups = this.groups.concat(m3uGroups);
-
-        // Map streams to channels
-        const channelList = streams.map(stream => ({
-            id: `m3u_${sourceId}_${stream.stream_id}`,
-            streamId: stream.stream_id,
-            name: stream.name,
-            tvgId: stream.epg_channel_id,
-            tvgLogo: stream.stream_icon,
-            url: stream.stream_url, // M3U has direct URLs
-            groupId: `m3u_${sourceId}_${stream.category_id}`,
-            groupTitle: categories.find(c => String(c.category_id) === String(stream.category_id))?.category_name || 'Uncategorized',
-            sourceId,
-            sourceType: 'm3u'
-        }));
-
-        this.channels = this.channels.concat(channelList);
+        this.groups = this.groups.concat(groups);
+        this.channels = this.channels.concat(channels);
     }
 
     /**

--- a/public/js/components/EpgGuide.js
+++ b/public/js/components/EpgGuide.js
@@ -15,6 +15,16 @@ class EpgGuide {
 
         this.channels = [];
         this.programmes = [];
+        // Set once the full +/-24h guide has been fetched. Until then `programmes` is
+        // empty and only `nowByChannel` is populated - callers that need a programme
+        // list (upcoming, guide grid) must check this rather than programmes.length.
+        this.fullEpgLoaded = false;
+        // channelId -> currently airing programme. Cheap to fetch, enough for the
+        // channel sidebar's "what's on now" line.
+        this.nowByChannel = new Map();
+        // channelId -> programme[], built from `programmes` so current-programme
+        // lookups don't linear-scan the whole guide once per channel row.
+        this.programmesByChannel = new Map();
         this.currentDate = new Date();
         this.timeOffset = 0; // Hours offset from now
         this.pixelsPerMinute = 6.67; // Width scaling (30min = 200px)
@@ -70,6 +80,17 @@ class EpgGuide {
 
         // Update current time indicator every minute
         setInterval(() => this.updateNowIndicator(), 60000);
+
+        // The background refresh skips hidden tabs, so catch up on the way back.
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden || !this._backgroundRefreshTimer) return;
+            this.fetchNowPlaying()
+                .then(() => {
+                    window.app?.channelList?.clearProgramInfoCache();
+                    window.app?.channelList?.updateVisibleEpgInfo?.();
+                })
+                .catch(() => { });
+        });
 
         this.initResizer();
     }
@@ -129,15 +150,20 @@ class EpgGuide {
         // Clear any existing timer
         this.stopBackgroundRefresh();
 
-        // Refresh display from cache every 5 minutes to pick up server-side sync results
+        // Refresh the *now playing* row set periodically to pick up server-side sync
+        // results. This used to re-fetch the entire +/-24h guide every 5 minutes,
+        // which on a large provider is a nine-figure byte count per hour, per tab,
+        // regardless of which page was open. Now-playing is a per-channel row set and
+        // is the only thing that actually changes minute to minute.
         const refreshIntervalMs = 5 * 60 * 1000; // 5 minutes
 
-        console.log('[EPG] Starting display refresh timer: every 5 minutes');
-
         this._backgroundRefreshTimer = setInterval(async () => {
-            console.log('[EPG] Refreshing EPG display from cache');
+            // Don't fetch for a tab nobody is looking at; the visibilitychange
+            // handler refreshes on the way back.
+            if (document.hidden) return;
+
             try {
-                await this.fetchEpgData(false); // Fetch cached data (no force refresh)
+                await this.fetchNowPlaying();
 
                 // Update channel list program info if visible
                 if (window.app?.channelList) {
@@ -171,10 +197,10 @@ class EpgGuide {
     /**
      * Load EPG data (server-side caching)
      */
-    async loadEpg(forceRefresh = false) {
+    async loadEpg() {
         try {
             this.container.innerHTML = '<div class="loading"></div>';
-            await this.fetchEpgData(forceRefresh);
+            await this.fetchEpgData();
             this.lastRefreshTime = new Date();
             this.render();
 
@@ -195,8 +221,57 @@ class EpgGuide {
     /**
      * Fetch EPG data from sources
      */
-    async fetchEpgData(forceRefresh = false) {
-        // Get ALL sources and filter for EPG-capable types
+    async fetchEpgData() {
+        const { channels, programmes } = await this._fetchFromSources(id => `/api/proxy/epg/${id}`);
+
+        this.channels = channels;
+        this.programmes = programmes;
+        this.fullEpgLoaded = true;
+
+        // channelId -> programmes, so getCurrentProgram() doesn't scan the whole guide
+        // once per rendered channel row.
+        this.programmesByChannel = new Map();
+        for (const p of programmes) {
+            let list = this.programmesByChannel.get(p.channelId);
+            if (!list) {
+                list = [];
+                this.programmesByChannel.set(p.channelId, list);
+            }
+            list.push(p);
+        }
+
+        this._indexChannels();
+        await this._loadFavourites();
+    }
+
+    /**
+     * Fetch only the currently-airing programme per channel.
+     * This is what the channel sidebar needs; it is a per-channel row set rather than
+     * the full +/-24h guide, so it is cheap enough to run at startup and on a timer.
+     */
+    async fetchNowPlaying() {
+        const { channels, programmes } = await this._fetchFromSources(id => `/api/proxy/epg/${id}/now`);
+
+        this.nowByChannel = new Map();
+        for (const p of programmes) {
+            // One row per channel expected; first wins if a provider overlaps them.
+            if (!this.nowByChannel.has(p.channelId)) {
+                this.nowByChannel.set(p.channelId, p);
+            }
+        }
+
+        // Only seed the channel list if the full guide hasn't already provided one.
+        if (!this.fullEpgLoaded) {
+            this.channels = channels;
+            this._indexChannels();
+            await this._loadFavourites();
+        }
+    }
+
+    /**
+     * Shared fetch/merge for the EPG endpoints. Returns merged channels + programmes.
+     */
+    async _fetchFromSources(urlFor) {
         const allSources = await API.sources.getAll();
         const sources = allSources.filter(s => (s.type === 'epg' || s.type === 'xtream') && s.enabled);
 
@@ -204,51 +279,37 @@ class EpgGuide {
             throw new Error('No EPG sources or Xtream accounts configured');
         }
 
-        // Build query params for server-side caching
-        // Sync interval is controlled by server, we just hint at max cache age
-        const maxAge = 24; // hours - server controls actual refresh
-        const queryParams = forceRefresh ? '?refresh=1' : `?maxAge=${maxAge}`;
-
-        // Load EPG from ALL sources in parallel
-        const fetchPromises = sources.map(async (source) => {
+        const results = await Promise.all(sources.map(async (source) => {
             try {
-                const response = await fetch(`/api/proxy/epg/${source.id}${queryParams}`);
+                const response = await fetch(urlFor(source.id));
                 if (!response.ok) throw new Error(`Status ${response.status}`);
                 return await response.json();
             } catch (e) {
                 console.warn(`Failed to load EPG for source ${source.name}:`, e);
                 return null;
             }
-        });
+        }));
 
-        const results = await Promise.all(fetchPromises);
-
-        // Merge results
-        this.channels = [];
-        this.programmes = [];
-
+        const channels = [];
+        const programmes = [];
         let hasData = false;
-        results.forEach(data => {
-            if (data) {
-                if (data.channels && data.channels.length > 0) {
-                    this.channels = this.channels.concat(data.channels);
-                }
-                if (data.programmes && data.programmes.length > 0) {
-                    this.programmes = this.programmes.concat(data.programmes);
-                }
-                if (data.channels || data.programmes) {
-                    hasData = true;
-                }
-            }
-        });
+
+        for (const data of results) {
+            if (!data) continue;
+            if (data.channels?.length) channels.push(...data.channels);
+            if (data.programmes?.length) programmes.push(...data.programmes);
+            if (data.channels || data.programmes) hasData = true;
+        }
 
         if (!hasData) {
             throw new Error('Failed to load EPG data from any source');
         }
 
-        // Build secondary indexes for faster lookup
+        return { channels, programmes };
+    }
+
+    _indexChannels() {
         this.channelMap = new Map();
-        // Index by ID
         this.channels.forEach(ch => {
             this.channelMap.set(ch.id, ch);
             // Also index by name (normalized) for fallback matching
@@ -256,8 +317,9 @@ class EpgGuide {
                 this.channelMap.set(ch.name.toLowerCase(), ch);
             }
         });
+    }
 
-        // Load favorites
+    async _loadFavourites() {
         const favs = await API.favorites.getAll();
         this.favorites = new Set(favs.map(f => `${f.source_id}:${f.item_id}`));
     }
@@ -269,7 +331,7 @@ class EpgGuide {
      * @returns {object|null} Program object with title, start, stop
      */
     getCurrentProgram(tvgId, channelName) {
-        if (!this.programmes || this.programmes.length === 0) return null;
+        if (!this.fullEpgLoaded && this.nowByChannel.size === 0) return null;
 
         // Find EPG channel using fast map lookup
         let epgChannel = null;
@@ -286,16 +348,26 @@ class EpgGuide {
 
         if (!epgChannel) return null;
 
-        const now = new Date();
-        const nowTime = now.getTime();
+        const nowTime = Date.now();
 
-        // Filter programs for this channel
-        const current = this.programmes.find(p => {
-            if (p.channelId !== epgChannel.id) return false;
-            const start = new Date(p.start).getTime();
-            const stop = new Date(p.stop).getTime();
-            return nowTime >= start && nowTime < stop;
-        });
+        // Prefer the full guide when it's loaded, via the per-channel index - scanning
+        // all programmes here was O(programmes) for every rendered channel row.
+        let current = null;
+        if (this.fullEpgLoaded) {
+            const forChannel = this.programmesByChannel.get(epgChannel.id);
+            current = forChannel?.find(p => {
+                const start = new Date(p.start).getTime();
+                const stop = new Date(p.stop).getTime();
+                return nowTime >= start && nowTime < stop;
+            }) || null;
+        } else {
+            // Sidebar-only data: already exactly one currently-airing row per channel,
+            // but it can go stale between refreshes, so still bounds-check it.
+            const p = this.nowByChannel.get(epgChannel.id);
+            if (p && nowTime >= new Date(p.start).getTime() && nowTime < new Date(p.stop).getTime()) {
+                current = p;
+            }
+        }
 
         return current ? {
             title: current.title,
@@ -893,8 +965,10 @@ class EpgGuide {
 
         title.textContent = data.title || 'Program Details';
 
-        const start = new Date(data.start);
-        const stop = new Date(data.stop);
+        // `data` is a DOMStringMap - the epoch ms in data-start/data-stop arrive here
+        // as strings, and new Date("1721900000000") is an Invalid Date. Coerce first.
+        const start = new Date(Number(data.start));
+        const stop = new Date(Number(data.stop));
 
         body.innerHTML = `
       <p><strong>Time:</strong> ${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} - ${stop.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</p>

--- a/public/js/components/VideoPlayer.js
+++ b/public/js/components/VideoPlayer.js
@@ -1268,8 +1268,11 @@ class VideoPlayer {
             return;
         }
         try {
-            // First, try to use the centralized EpgGuide data (already loaded)
-            if (window.app && window.app.epgGuide && window.app.epgGuide.programmes) {
+            // First, try to use the centralized EpgGuide data, but only when the full
+            // guide is loaded - the startup now-playing set has no upcoming programmes,
+            // so without this we'd short-circuit the short_epg fallback below and lose
+            // the "up next" list.
+            if (window.app?.epgGuide?.fullEpgLoaded) {
                 const epgGuide = window.app.epgGuide;
 
                 // Get current program from EpgGuide

--- a/public/js/pages/Guide.js
+++ b/public/js/pages/Guide.js
@@ -21,8 +21,10 @@ class GuidePage {
             await channelList.loadChannels();
         }
 
-        // Only load EPG data if not already loaded
-        if (!this.app.epgGuide.programmes || this.app.epgGuide.programmes.length === 0) {
+        // Only load EPG data if not already loaded.
+        // Checks fullEpgLoaded, not programmes.length - startup populates the
+        // now-playing set only, which is not enough to render the guide grid.
+        if (!this.app.epgGuide.fullEpgLoaded) {
             await this.app.epgGuide.loadEpg();
         } else {
             // Just re-render with existing data (updates time position)

--- a/server/db/sqlite.js
+++ b/server/db/sqlite.js
@@ -88,6 +88,11 @@ function initSchema() {
         );
         CREATE INDEX IF NOT EXISTS idx_epg_channel_time ON epg_programs(channel_id, start_time, end_time);
         CREATE INDEX IF NOT EXISTS idx_epg_cleanup ON epg_programs(end_time); -- For deleting old programs
+        -- Per-source time-window reads. The trailing columns make this a COVERING
+        -- index for the now-playing query (which selects no description), taking it
+        -- from ~10s to <100ms at 1.5M rows by removing the per-row table lookup.
+        -- The (source_id, start_time) prefix also serves the full guide query.
+        CREATE INDEX IF NOT EXISTS idx_epg_source_start ON epg_programs(source_id, start_time, end_time, channel_id, title);
     `);
 
     // Sync Status

--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,9 @@ const PORT = process.env.PORT || 3000;
 app.set('trust proxy', true);
 
 // Middleware
+// gzip all responses. The catalogue/EPG JSON payloads are tens of MB uncompressed
+// and compress ~20x, so this dominates wall-clock time on every browse request.
+app.use(require('compression')());
 app.use(express.json({ limit: '50mb' }));
 
 // Initialize Passport

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -326,9 +326,14 @@ router.get('/epg/:sourceId', async (req, res) => {
         const windowEnd = Date.now() + (24 * 60 * 60 * 1000);   // +24 hours
 
         // Fetch programs within the time window
+        // `data` is deliberately not selected - nothing on the client reads it, and it
+        // is the largest column in the table.
+        // start/stop go out as epoch ms rather than ISO strings: it drops two
+        // Date allocations + toISOString() per row, and shortens the payload.
+        // Every client parse site goes through `new Date(...)`, which accepts both.
         let programsQuery = `
-            SELECT channel_id as channelId, start_time, end_time, title, description, data 
-            FROM epg_programs 
+            SELECT channel_id as channelId, start_time, end_time, title, description
+            FROM epg_programs
             WHERE source_id = ? AND end_time > ? AND start_time < ?
         `;
         const params = [sourceId, windowStart, windowEnd];
@@ -337,8 +342,8 @@ router.get('/epg/:sourceId', async (req, res) => {
 
         const formattedPrograms = programs.map(p => ({
             channelId: p.channelId,
-            start: new Date(p.start_time).toISOString(), // EpgGuide parse this back
-            stop: new Date(p.end_time).toISOString(),
+            start: p.start_time,
+            stop: p.end_time,
             title: p.title,
             description: p.description
         }));
@@ -377,9 +382,68 @@ router.get('/epg/:sourceId', async (req, res) => {
     }
 });
 
+// Currently-airing programme only, one row per channel.
+// The channel sidebar only ever renders "what's on now", which previously cost it the
+// full +/-24h guide (hundreds of thousands of rows). This serves the same need from
+// roughly one row per channel. The full /epg/:sourceId payload is for the Guide page.
+router.get('/epg/:sourceId/now', (req, res) => {
+    try {
+        const sourceId = parseInt(req.params.sourceId);
+        if (Number.isNaN(sourceId)) {
+            return res.status(400).json({ error: 'Invalid source id' });
+        }
+
+        const db = getDb();
+        const now = Date.now();
+
+        // Served entirely from idx_epg_source_start as a covering index, so `description`
+        // is deliberately not selected - including it forces a table lookup per row and
+        // costs two orders of magnitude. The sidebar only renders the title.
+        //
+        // The start_time lower bound is what makes the index range small: without it
+        // SQLite walks every programme this source has ever had up to now (~1400x
+        // slower measured). A programme that started earlier than this and is still
+        // running will be missed, so the bound is set well past any real programme
+        // length - providers do emit multi-day "Program" placeholder entries.
+        const MAX_PROGRAMME_MS = 48 * 60 * 60 * 1000;
+        const programs = db.prepare(`
+            SELECT channel_id as channelId, start_time, end_time, title
+            FROM epg_programs
+            WHERE source_id = ? AND start_time > ? AND start_time <= ? AND end_time > ?
+        `).all(sourceId, now - MAX_PROGRAMME_MS, now, now);
+
+        const channels = db.prepare(`
+            SELECT item_id as id, name, stream_icon as icon
+            FROM playlist_items
+            WHERE source_id = ? AND type = 'epg_channel'
+        `).all(sourceId);
+
+        res.json({
+            channels: channels.length > 0
+                ? channels
+                : [...new Set(programs.map(p => p.channelId))].map(id => ({ id, name: id })),
+            programmes: programs.map(p => ({
+                channelId: p.channelId,
+                start: p.start_time,
+                stop: p.end_time,
+                title: p.title
+            }))
+        });
+    } catch (err) {
+        console.error('EPG now-playing error:', err);
+        res.status(500).json({ error: 'Database error' });
+    }
+});
+
 // Clear cache (kept for compatibility)
 router.delete('/cache/:sourceId', (req, res) => {
-    const sourceId = req.params.sourceId;
+    // Source ids are always numeric. Anything else is a path-traversal attempt
+    // against the recursive delete in cache.clearSource().
+    const sourceId = parseInt(req.params.sourceId, 10);
+    if (Number.isNaN(sourceId)) {
+        return res.status(400).json({ error: 'Invalid source id' });
+    }
+
     cache.clearSource(sourceId);
     res.json({ success: true });
 });
@@ -495,61 +559,14 @@ router.get('/xtream/:sourceId/stream/:streamId/:type?', async (req, res) => {
     }
 });
 
-/**
- * Fetch and parse EPG (with file-based caching)
- * GET /api/proxy/epg/:sourceId
- * Query params:
- *   - refresh=1  Force refresh, bypass cache
- *   - maxAge=N   Max cache age in hours (default 24)
- */
-router.get('/epg/:sourceId', async (req, res) => {
-    try {
-        const sourceId = req.params.sourceId;
-        const source = await sources.getById(sourceId);
-        if (!source || (source.type !== 'epg' && source.type !== 'xtream')) {
-            return res.status(404).json({ error: 'Valid EPG source not found' });
-        }
-
-        const forceRefresh = req.query.refresh === '1';
-        const maxAgeHours = parseInt(req.query.maxAge) || DEFAULT_MAX_AGE_HOURS;
-        const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
-
-        // Check file cache (unless force refresh)
-        if (!forceRefresh) {
-            const cached = cache.get('epg', sourceId, 'data', maxAgeMs);
-            if (cached) {
-                return res.json(cached);
-            }
-        }
-
-        // Fetch fresh data
-        let url = source.url;
-        if (source.type === 'xtream') {
-            const api = xtreamApi.createFromSource(source);
-            url = api.getXmltvUrl();
-        }
-
-        const data = await epgParser.fetchAndParse(url);
-
-        // Store in file cache
-        cache.set('epg', sourceId, 'data', data);
-
-        res.json(data);
-    } catch (err) {
-        console.error('EPG proxy error:', err);
-        res.status(500).json({ error: err.message });
-    }
-});
-
-/**
- * Clear cache for a source
- * DELETE /api/proxy/cache/:sourceId
- */
-router.delete('/cache/:sourceId', (req, res) => {
-    const sourceId = req.params.sourceId;
-    cache.clearSource(sourceId);
-    res.json({ success: true });
-});
+// Removed: a second `GET /epg/:sourceId` and a second `DELETE /cache/:sourceId`
+// lived here. Express is first-match-wins, so both were shadowed by the handlers
+// earlier in this file and had never run. The dead EPG copy went upstream to the
+// provider and implemented ?refresh=1 / ?maxAge=N, which is why those query params
+// appeared to do nothing - the live handler at the top reads from SQLite and ignores
+// them. Callers have been updated to stop sending them.
+// Note there is still a shadowed `GET /xtream/:sourceId/stream/:streamId/:type?`
+// above; left alone here as it is not part of this change.
 
 /**
  * Clear EPG cache for a source (legacy endpoint, calls clearSource)

--- a/server/services/cache.js
+++ b/server/services/cache.js
@@ -9,9 +9,32 @@ const path = require('path');
 // Cache directory
 const cacheDir = path.join(__dirname, '..', '..', 'data', 'cache');
 
+const CACHE_TYPES = ['epg', 'm3u', 'xtream'];
+
+/**
+ * Resolve the directory for one source's cache of one type.
+ * `sourceId` reaches here URL-decoded from a route param, so a value like
+ * `../../..` would escape cacheDir and hand fs.rmSync an arbitrary directory.
+ * Throw rather than clamp: a traversal attempt is never a legitimate call.
+ */
+function resolveSourceDir(type, sourceId) {
+    if (!CACHE_TYPES.includes(type)) {
+        throw new Error(`Unknown cache type: ${type}`);
+    }
+
+    const dir = path.resolve(cacheDir, type, String(sourceId));
+    const root = path.resolve(cacheDir, type);
+
+    if (dir !== root && !dir.startsWith(root + path.sep)) {
+        throw new Error(`Invalid cache source id: ${sourceId}`);
+    }
+
+    return dir;
+}
+
 // Ensure cache directories exist
 function ensureCacheDir(type, sourceId) {
-    const dir = path.join(cacheDir, type, String(sourceId));
+    const dir = resolveSourceDir(type, sourceId);
     if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
     }
@@ -94,16 +117,18 @@ function clear(type, sourceId, key) {
  * Clear all cache for a source
  */
 function clearSource(sourceId) {
-    try {
-        const types = ['epg', 'm3u', 'xtream'];
-        for (const type of types) {
-            const dir = path.join(cacheDir, type, String(sourceId));
+    // Resolve every path first so a traversal attempt throws to the caller before
+    // anything is deleted, rather than being swallowed after a partial wipe.
+    const dirs = CACHE_TYPES.map(type => resolveSourceDir(type, sourceId));
+
+    for (const dir of dirs) {
+        try {
             if (fs.existsSync(dir)) {
                 fs.rmSync(dir, { recursive: true });
             }
+        } catch (err) {
+            console.warn(`Cache clear source error:`, err.message);
         }
-    } catch (err) {
-        console.warn(`Cache clear source error:`, err.message);
     }
 }
 


### PR DESCRIPTION
## Problem

Opening the app on a large Xtream provider took over ten seconds. The cause is that `app.js` fetched the **entire ±24h EPG at every boot, on every page**, and then re-fetched it **every 5 minutes** for the lifetime of the tab — `EpgGuide.startBackgroundRefresh()` had no visibility check and no page scoping. Nothing in the channel sidebar needed more than the currently-airing programme title.

Measured on a real provider with 111K live channels, 354K movies and 461K EPG programmes:

| | before | after |
|---|---|---|
| Boot EPG query | 9,781 ms / 69.9 MB | **7 ms / 0.4 MB** |
| Full boot path | >10 s / ~96 MB | **0.7 s / 1.7 MB** gzipped |
| Channel list payload | 26 MB | 1.54 MB gzipped |

## Changes

**Serve the sidebar what it actually needs.** New `GET /api/proxy/epg/:sourceId/now` returns one row per channel. Startup loads that; the full guide is now fetched lazily by `GuidePage.show()`, which already had the branch for it.

**Index.** `idx_epg_source_start` becomes `(source_id, start_time, end_time, channel_id, title)`. The extra columns make it a *covering* index for the now-playing query — including `description` forces a per-row table lookup and costs ~125x (10.4 s → 83 ms in isolation). The `(source_id, start_time)` prefix also fixes the full-guide query, which had been falling back to `idx_epg_cleanup` and scanning nearly the whole table.

The now-playing query is bounded below on `start_time`; unbounded, SQLite walks every programme the source has ever had (~1400x slower measured). The 48h bound is deliberate — at 24h it dropped a real 103-hour placeholder entry that providers do emit.

**gzip.** `compression` middleware; the channel list ships as 1.5 MB instead of 26 MB.

**Remove two shadowed routes.** A second `GET /epg/:sourceId` and `DELETE /cache/:sourceId` were defined later in `proxy.js`. Express is first-match-wins, so neither had ever run — which is why `?refresh=1` and `?maxAge=N` silently did nothing. Callers updated to stop sending them.

**Smaller fixes.** `getCurrentProgram()` linear-scanned all programmes once per rendered channel row (now indexed by channel id). `ChannelList` had `categories.find()` inside `streams.map()` (now a `Map`) and loaded sources strictly serially (now concurrent). The guide SELECT no longer pulls the unused `data` column and sends epoch ms rather than ISO strings.

**Path traversal in the cache clear.** `sourceId` reached `fs.rmSync(dir, {recursive:true})` URL-decoded and unvalidated, so `DELETE /api/proxy/cache/..%2f..%2f..` escaped the cache directory. Now rejects non-numeric ids and asserts path containment. Unauthenticated before this change.

## Compatibility

No API removals — `/epg/:sourceId` keeps its shape and its `description` field. The one client-side subtlety: `start`/`stop` are now epoch ms, and they round-trip through `dataset` as strings in the guide grid, so `showProgramDetails` coerces with `Number()` (`new Date("1784908800000")` is an Invalid Date).

## Testing

There is no test suite in the repo, so this was verified manually against a real large provider: query plans confirmed via `EXPLAIN QUERY PLAN`, payload sizes and timings measured over HTTP, and the sidebar lookup chain (`stream.epg_channel_id` → `channelMap` → `programme.channelId`) checked end-to-end — 6,127 channels resolve to a now-playing title. Fresh-database path confirmed: the index is created correctly on first boot.

The full guide is still ~7.8 s / 22 MB when the Guide page is opened. That is unchanged by this PR beyond no longer running at startup; paginating it by day/category is the follow-up.
