### PR TITLE
Add Xtream DNS failover and customizable multi-view

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.env
+.env.*
+!.env.example
+data
+transcode-cache
+node_modules
+coverage
+dist
+release
+user_data
+.vscode
+*.log
+npm-debug.log*

--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,10 @@ SEED_XTREAM_URL=http://primary-server.example
 SEED_XTREAM_FALLBACK_URLS=http://backup-1.example,http://backup-2.example
 SEED_XTREAM_USERNAME=your_username
 SEED_XTREAM_PASSWORD=your_password
+
+# Security defaults: keep HOST on loopback unless you intentionally use a firewall/reverse proxy.
+HOST=127.0.0.1
+# Optional: set a random value with at least 32 characters. Otherwise NodeCast creates one in data/.
+JWT_SECRET=
+# Only enable this if you intentionally connect to an IPTV server on your private network.
+ALLOW_PRIVATE_UPSTREAMS=false

--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,7 @@ SEED_XTREAM_PASSWORD=your_password
 HOST=127.0.0.1
 # Optional: set a random value with at least 32 characters. Otherwise NodeCast creates one in data/.
 JWT_SECRET=
+# Local login lifetime. The hardened Docker configuration uses 30 days.
+JWT_EXPIRY=30d
 # Only enable this if you intentionally connect to an IPTV server on your private network.
 ALLOW_PRIVATE_UPSTREAMS=false

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Optional local seed. Copy this file to .env and fill the values.
+# The source is created only when no Xtream source exists yet.
+SEED_XTREAM_NAME=My IPTV
+SEED_XTREAM_URL=http://primary-server.example
+SEED_XTREAM_FALLBACK_URLS=http://backup-1.example,http://backup-2.example
+SEED_XTREAM_USERNAME=your_username
+SEED_XTREAM_PASSWORD=your_password

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,42 @@
-# NodeCast TV Docker Image
-#
-# Hardware acceleration:
-#   - VAAPI (Intel/AMD): Mount /dev/dri and add video/render groups
-#   - NVIDIA NVENC: Requires nvidia-container-toolkit on host + --gpus flag
-#   - Intel QSV: Mount /dev/dri
-#
-# Build: docker compose build
-# Run with VAAPI: docker run --device /dev/dri:/dev/dri --group-add video ...
-
-FROM ubuntu:24.04
-
-# Install Node.js, FFmpeg, and hardware acceleration drivers
-ARG TARGETARCH
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && if [ "$TARGETARCH" = "amd64" ]; then \
-        DRIVERS="mesa-va-drivers intel-media-va-driver vainfo"; \
-    else \
-        DRIVERS=""; \
-    fi \
-    && apt-get update && apt-get install -y --no-install-recommends \
-    nodejs \
-    ffmpeg \
-    python3 \
-    make \
-    g++ \
-    $DRIVERS \
-    && rm -rf /var/lib/apt/lists/*
-
-# Verify FFmpeg installed
-RUN ffmpeg -version && ffmpeg -encoders 2>/dev/null | grep -E "vaapi|nvenc|qsv|libx264" | head -10
+# Build native Node dependencies separately so compilers are not present in the
+# runtime image that processes untrusted IPTV media.
+FROM node:24-trixie-slim AS dependencies
 
 WORKDIR /app
 
-# Copy package files
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
 
-# Install dependencies (better-sqlite3 will build from source using g++ installed above)
-RUN npm ci --only=production
 
-# Copy application files
-COPY . .
+FROM node:24-trixie-slim AS runtime
 
-# Create data and cache directories
-RUN mkdir -p /app/data /app/transcode-cache && chmod 777 /app/transcode-cache
+ENV NODE_ENV=production \
+    HOST=0.0.0.0 \
+    PORT=3000
 
-# Expose port
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=dependencies --chown=node:node /app/node_modules ./node_modules
+COPY --chown=node:node . .
+
+RUN mkdir -p /app/data /app/transcode-cache \
+    && chown -R node:node /app/data /app/transcode-cache
+
+# The official image's unprivileged user prevents Node.js and FFmpeg from
+# running as root inside the container.
+USER node
+
 EXPOSE 3000
 
-# Start server
 CMD ["node", "server/index.js"]

--- a/README.md
+++ b/README.md
@@ -66,32 +66,29 @@ nodecast-tv is a modern, web-based IPTV player featuring Live TV, EPG, Movies (V
 
 ### Docker Deployment
 
-You can run nodecast-tv easily using Docker.
+The included Compose configuration builds the checked-out local code, persists
+only `data/`, and publishes the app exclusively on the host loopback interface.
+The runtime uses an unprivileged user, a read-only root filesystem, dropped
+Linux capabilities, `no-new-privileges`, and temporary in-memory transcode
+storage. `.env` and `data/` are excluded from the image build context.
 
-1.  Create a `docker-compose.yml` file (or copy the one from this repo):
-
-    ```yaml
-    services:
-      nodecast-tv:
-        build: https://github.com/technomancer702/nodecast-tv.git#main
-        container_name: nodecast-tv
-        ports:
-          - "3000:3000" # Host:Container
-        volumes:
-          - ./data:/app/data
-        restart: unless-stopped
-        environment:
-          - NODE_ENV=production
-          - PORT=3000 # Optional: Internal container port
-          - HOST=0.0.0.0 # Required inside the container
-    ```
-
-2.  Run the container:
+1.  Start Docker Desktop.
+2.  Build and run the local container:
     ```bash
-    docker-compose up -d
+    docker compose up --build -d
     ```
 
-The application will be available at `http://localhost:3000`.
+The application will be available only on this computer at
+`http://127.0.0.1:3000`.
+
+Use `docker compose logs -f` to inspect logs and `docker compose down` to stop
+the app. To refresh the Node.js base image, FFmpeg security packages, and npm
+dependencies after updating the repository, run:
+
+```bash
+docker compose build --pull --no-cache
+docker compose up -d
+```
 
 
 ### Hardware Acceleration Setup

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ SEED_XTREAM_PASSWORD=your_password
 - Provider metadata is escaped before HTML rendering, and Content Security Policy headers block unapproved scripts and external connections.
 - NodeCast automatically keeps HTTPS across provider redirects when the redirected media host supports it.
 - A strong persistent JWT secret is generated under `data/` when `JWT_SECRET` is not configured.
+- Login lifetime is configurable through `JWT_EXPIRY`; the local Docker configuration uses 30 days.
+- Provider authentication errors do not invalidate the NodeCast login session.
 
 If your provider intentionally runs on a private LAN address, set `ALLOW_PRIVATE_UPSTREAMS=true`. This weakens SSRF protection and should not be enabled for internet-supplied playlists.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ nodecast-tv is a modern, web-based IPTV player featuring Live TV, EPG, Movies (V
     npm run dev
     ```
 
-4.  Open your browser at `http://localhost:3000`.
+4.  Open your browser at `http://127.0.0.1:3000`.
 
 ### Docker Deployment
 
@@ -83,6 +83,7 @@ You can run nodecast-tv easily using Docker.
         environment:
           - NODE_ENV=production
           - PORT=3000 # Optional: Internal container port
+          - HOST=0.0.0.0 # Required inside the container
     ```
 
 2.  Run the container:
@@ -163,6 +164,17 @@ SEED_XTREAM_FALLBACK_URLS=http://backup-1.example,http://backup-2.example
 SEED_XTREAM_USERNAME=your_username
 SEED_XTREAM_PASSWORD=your_password
 ```
+
+### Security defaults
+
+- Local installs listen only on `127.0.0.1` by default. Set `HOST` only when you intentionally deploy behind a firewall or reverse proxy.
+- Provider passwords remain server-side. Playback URLs exposed to the browser use encrypted, process-local tokens.
+- External proxy requests allow only HTTP/HTTPS and reject localhost, private-network, reserved, and oversized image responses by default.
+- Provider metadata is escaped before HTML rendering, and Content Security Policy headers block unapproved scripts and external connections.
+- NodeCast automatically keeps HTTPS across provider redirects when the redirected media host supports it.
+- A strong persistent JWT secret is generated under `data/` when `JWT_SECRET` is not configured.
+
+If your provider intentionally runs on a private LAN address, set `ALLOW_PRIVATE_UPSTREAMS=true`. This weakens SSRF protection and should not be enabled for internet-supplied playlists.
 
 
 ## Browser Codec Support & Transcoding

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ nodecast-tv is a modern, web-based IPTV player featuring Live TV, EPG, Movies (V
 ## Features
 
 - **📺 Live TV**: Fast channel zapping, category grouping, and search.
+- **🖥️ Multi-view**: Watch 1–4 live channels in customizable layouts, with one active audio feed at a time.
 - **📅 TV Guide (EPG)**: Interactive grid guide with 24h timeline, search, and dynamic resizing.
 - **🎬 VOD Support**: Dedicated sections for Movies and TV Series with rich metadata, posters, and seasonal episode lists.
 - **❤️ Favorites System**: Unified favorites for channels, movies, and series with instant synchronization.
@@ -17,6 +18,7 @@ nodecast-tv is a modern, web-based IPTV player featuring Live TV, EPG, Movies (V
 - **⚡ High Performance**: Optimized for large playlists (7000+ channels) using virtual scrolling and batch rendering.
 - **⚙️ Management**: 
   - Support for Xtream Codes and M3U playlists.
+  - Automatic Xtream DNS failover with multiple fallback server URLs.
   - Manage hidden content categories.
   - Playback preferences (volume memory, auto-play).
 - **🎛️ Hardware Transcoding**: GPU-accelerated transcoding with NVIDIA NVENC, AMD AMF, Intel QuickSync, and VAAPI support.
@@ -139,6 +141,28 @@ OIDC_CALLBACK_URL=http://localhost:3000/api/auth/oidc/callback # Adjust for your
 2.  Add your IPTV provider details (Xtream Codes or M3U URL).
 3.  Click "Refresh Sources".
 4.  Navigate to **Live TV**, **Movies**, or **Series** to browse your content.
+
+### Xtream DNS Failover
+
+Xtream sources can include multiple alternative DNS/server URLs. Go to **Settings → Content Sources**, edit an Xtream source, and add one fallback URL per line under **Alternative DNS URLs**. NodeCast TV remembers the responsive server and automatically tries another configured URL when API, EPG, or playback startup fails.
+
+### Multi-view
+
+Open **Multi-view** from the navigation bar and choose a layout with 1, 2, 3, or 4 screens. Each tile has its own channel picker, fullscreen control, and audio toggle. Only one tile is unmuted at a time, and streams are stopped automatically when a tile is removed or the page is closed.
+
+> Each active tile normally counts as a separate provider connection. Make sure your IPTV subscription allows the number of simultaneous streams you select.
+
+### Optional Local Xtream Seed
+
+For local or container-based setups, an initial Xtream source can be created from environment variables when no Xtream source exists yet. Existing sources and changes made through the UI are never overwritten.
+
+```env
+SEED_XTREAM_NAME=My IPTV
+SEED_XTREAM_URL=http://primary-server.example
+SEED_XTREAM_FALLBACK_URLS=http://backup-1.example,http://backup-2.example
+SEED_XTREAM_USERNAME=your_username
+SEED_XTREAM_PASSWORD=your_password
+```
 
 
 ## Browser Codec Support & Transcoding

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3000"
+      # Avoid interrupting long-running local viewing sessions every 24 hours.
+      JWT_EXPIRY: 30d
       # The container has its own network namespace; the host-side port above
       # remains restricted to 127.0.0.1.
       HOST: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,42 @@
 services:
   nodecast-tv:
-    image: ghcr.io/technomancer702/nodecast-tv:latest
-    build: https://github.com/technomancer702/nodecast-tv.git#main
+    image: nodecast-tv:local-secure
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: nodecast-tv
+    init: true
     ports:
-      - "3000:3000"
+      # Publish only to this computer, never to the LAN or internet.
+      - "127.0.0.1:3000:3000"
     volumes:
-      - ./data:/app/data
-    restart: unless-stopped
+      - type: bind
+        source: ./data
+        target: /app/data
     environment:
-      - HOST=0.0.0.0
-      - NODE_ENV=production
-      - PORT=3000 # Internal container port
+      NODE_ENV: production
+      PORT: "3000"
+      # The container has its own network namespace; the host-side port above
+      # remains restricted to 127.0.0.1.
+      HOST: 0.0.0.0
+      ALLOW_PRIVATE_UPSTREAMS: "false"
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=128m
+      - /app/transcode-cache:rw,noexec,nosuid,nodev,uid=1000,gid=1000,mode=0750,size=1g
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:3000/login.html').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,6 @@ services:
       - ./data:/app/data
     restart: unless-stopped
     environment:
+      - HOST=0.0.0.0
       - NODE_ENV=production
       - PORT=3000 # Internal container port

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,9 @@
                 "bcryptjs": "^3.0.3",
                 "better-sqlite3": "^12.5.0",
                 "dotenv": "^17.2.3",
-                "express": "^4.18.2",
+                "express": "^4.22.2",
                 "express-session": "^1.18.2",
+                "hls.js": "^1.7.0",
                 "jsonwebtoken": "^9.0.3",
                 "passport": "^0.7.0",
                 "passport-jwt": "^4.0.1",
@@ -303,9 +304,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.6",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+            "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "~3.1.2",
@@ -316,7 +317,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -615,9 +616,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -651,14 +652,14 @@
             }
         },
         "node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -677,7 +678,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -857,9 +858,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -867,6 +868,12 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/hls.js": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.7.0.tgz",
+            "integrity": "sha512-NnQpT6Z//+2IB2qovSUbKbrlXY1MOpi0JynZ9L2NNOuTJiNCyMSQj9k2laEj1v7CxU/Hb8oTWR98eT3mVpPQVQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/http-errors": {
             "version": "2.0.1",
@@ -1338,9 +1345,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
         },
         "node_modules/pause": {
@@ -1408,12 +1415,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -1580,14 +1588,14 @@
             "license": "ISC"
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -1599,13 +1607,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "main": "server/index.js",
     "scripts": {
         "start": "node server/index.js",
-        "dev": "node --watch server/index.js"
+        "dev": "node --watch server/index.js",
+        "test": "node --test"
     },
     "dependencies": {
         "@ffprobe-installer/ffprobe": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.5.0",
         "dotenv": "^17.2.3",
-        "express": "^4.18.2",
+        "express": "^4.22.2",
         "express-session": "^1.18.2",
+        "hls.js": "^1.7.0",
         "jsonwebtoken": "^9.0.3",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -26,6 +27,9 @@
     },
     "optionalDependencies": {
         "ffmpeg-static": "^5.3.0"
+    },
+    "overrides": {
+        "path-to-regexp": "0.1.13"
     },
     "engines": {
         "node": ">=18.0.0"

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -4820,3 +4820,437 @@ kbd {
     max-width: 70px;
   }
 }
+/* =====================================================
+   Multi-view
+   ===================================================== */
+.multiview-shell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  height: 100%;
+  padding: var(--space-lg);
+  overflow: hidden;
+}
+
+.multiview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+}
+
+.multiview-header h2 {
+  font-size: 1.6rem;
+  margin-bottom: var(--space-xs);
+}
+
+.multiview-header p,
+.multiview-picker-header p {
+  color: var(--color-text-secondary);
+}
+
+.multiview-header-actions,
+.multiview-screen-count {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.multiview-screen-count {
+  padding: 4px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.multiview-screen-count span {
+  padding: 0 6px;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.multiview-screen-count button {
+  width: 32px;
+  height: 32px;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.multiview-screen-count button:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-hover);
+}
+
+.multiview-screen-count button.active {
+  color: white;
+  background: var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.multiview-connection-warning {
+  padding: 10px 14px;
+  color: #fcd34d;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: var(--radius-md);
+}
+
+.multiview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: var(--space-md);
+  flex: 1;
+  min-height: 0;
+}
+
+.multiview-grid.screens-1 {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.multiview-grid.screens-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.multiview-grid.screens-3 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+}
+
+.multiview-grid.screens-3 .multiview-tile:first-child {
+  grid-row: 1 / span 2;
+}
+
+.multiview-grid.screens-4 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+}
+
+.multiview-tile.is-hidden {
+  display: none;
+}
+
+.multiview-tile {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  isolation: isolate;
+  background: #050507;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.multiview-tile.audio-active {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent), var(--shadow-glow);
+}
+
+.multiview-video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
+.multiview-empty,
+.multiview-loading,
+.multiview-error {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  text-align: center;
+}
+
+.multiview-slot-number {
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.multiview-loading {
+  display: none;
+  z-index: 3;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.multiview-tile.is-loading .multiview-loading {
+  display: flex;
+}
+
+.multiview-tile.has-channel .multiview-empty {
+  display: none;
+}
+
+.multiview-tile-topbar,
+.multiview-tile-controls {
+  position: absolute;
+  z-index: 4;
+  right: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 10px 12px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+  pointer-events: none;
+}
+
+.multiview-tile-topbar {
+  top: 0;
+  justify-content: space-between;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.85), transparent);
+}
+
+.multiview-tile-controls {
+  bottom: 0;
+  justify-content: flex-end;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.9), transparent);
+}
+
+.multiview-tile.has-channel:hover .multiview-tile-topbar,
+.multiview-tile.has-channel:hover .multiview-tile-controls,
+.multiview-tile.has-error .multiview-tile-topbar,
+.multiview-tile.has-error .multiview-tile-controls {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.multiview-channel-title {
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.multiview-control-btn,
+.multiview-icon-btn {
+  color: white;
+  background: rgba(20, 20, 28, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.multiview-control-btn {
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+}
+
+.multiview-icon-btn {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: var(--radius-full);
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.multiview-control-btn:hover,
+.multiview-icon-btn:hover {
+  background: var(--color-accent);
+  border-color: var(--color-accent-hover);
+}
+
+.multiview-error {
+  display: none;
+  z-index: 3;
+  padding: var(--space-xl);
+  color: #fecaca;
+  background: rgba(20, 4, 7, 0.9);
+}
+
+.multiview-tile.has-error .multiview-error {
+  display: flex;
+}
+
+.multiview-picker {
+  position: fixed;
+  z-index: 300;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(6px);
+}
+
+.multiview-picker.active {
+  display: flex;
+}
+
+.multiview-picker-panel {
+  display: flex;
+  flex-direction: column;
+  width: min(760px, 100%);
+  max-height: min(780px, 90vh);
+  overflow: hidden;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+
+.multiview-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.multiview-picker-filters {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1.3fr;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.multiview-channel-results {
+  overflow-y: auto;
+  padding: var(--space-sm);
+}
+
+.multiview-channel-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  width: 100%;
+  padding: 10px 12px;
+  color: var(--color-text-primary);
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.multiview-channel-option:hover {
+  background: var(--color-bg-hover);
+}
+
+.multiview-channel-option img {
+  width: 48px;
+  height: 36px;
+  flex: 0 0 auto;
+  object-fit: contain;
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-sm);
+}
+
+.multiview-channel-option span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.multiview-channel-option strong,
+.multiview-channel-option small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.multiview-channel-option small {
+  color: var(--color-text-secondary);
+}
+
+.multiview-picker-empty {
+  padding: var(--space-2xl);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.multiview-tile:fullscreen {
+  border: 0;
+  border-radius: 0;
+}
+
+@media (max-width: 768px) {
+  #page-multiview.active {
+    overflow-y: auto;
+  }
+
+  .multiview-shell {
+    height: auto;
+    min-height: 100%;
+    padding: var(--space-md);
+    overflow: visible;
+  }
+
+  .multiview-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .multiview-header p {
+    display: none;
+  }
+
+  .multiview-grid,
+  .multiview-grid.screens-1,
+  .multiview-grid.screens-2,
+  .multiview-grid.screens-3,
+  .multiview-grid.screens-4 {
+    grid-template-columns: 1fr;
+    grid-template-rows: none;
+  }
+
+  .multiview-grid.screens-3 .multiview-tile:first-child {
+    grid-row: auto;
+  }
+
+  .multiview-header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .multiview-tile {
+    min-height: 220px;
+    aspect-ratio: 16 / 9;
+  }
+
+  .multiview-tile.has-channel .multiview-tile-topbar,
+  .multiview-tile.has-channel .multiview-tile-controls {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .multiview-picker {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .multiview-picker-panel {
+    width: 100%;
+    max-height: 92vh;
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  }
+
+  .multiview-picker-filters {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .multiview-picker-filters .search-input {
+    grid-column: 1 / -1;
+  }
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -5069,6 +5069,31 @@ kbd {
   border-color: var(--color-accent-hover);
 }
 
+.multiview-exit-fullscreen {
+  position: absolute;
+  z-index: 6;
+  top: 18px;
+  right: 18px;
+  display: none;
+  align-items: center;
+  min-height: 42px;
+  padding: 9px 14px;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 700;
+  background: rgba(15, 15, 22, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+}
+
+.multiview-exit-fullscreen:hover,
+.multiview-exit-fullscreen:focus-visible {
+  background: var(--color-accent);
+  border-color: var(--color-accent-hover);
+}
+
 .multiview-error {
   display: none;
   z-index: 3;
@@ -5183,6 +5208,11 @@ kbd {
 .multiview-tile:fullscreen {
   border: 0;
   border-radius: 0;
+}
+
+.multiview-tile:fullscreen .multiview-exit-fullscreen,
+.multiview-tile:-webkit-full-screen .multiview-exit-fullscreen {
+  display: inline-flex;
 }
 
 @media (max-width: 768px) {

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@800&display=swap"
     rel="stylesheet">
   <!-- HLS.js for video playback -->
-  <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.7/dist/hls.min.js"></script>
+  <script src="/vendor/hls.min.js"></script>
 </head>
 
 <body>
@@ -1152,6 +1152,7 @@
   </div>
 
   <!-- JavaScript -->
+  <script src="/js/security.js"></script>
   <script src="/js/icons.js"></script>
   <script src="/js/api.js?v=2"></script>
   <script src="/js/components/VideoPlayer.js?v=2"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
   <title>nodecast-tv | IPTV Player</title>
   <meta name="description" content="Stream live TV, movies, and series with EPG support">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <link rel="stylesheet" href="css/main.css">
+  <link rel="stylesheet" href="css/main.css?v=3">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@800&display=swap"
@@ -57,6 +57,13 @@
                 d="M21 6h-7.59l3.29-3.29L16 2l-4 4-4-4-.71.71L10.59 6H3a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8a2 2 0 0 0-2-2zm0 14H3V8h18v12zM9 10v8l7-4z" />
             </svg></span>
           <span>Live TV</span>
+        </a>
+        <a href="#" class="nav-link" data-page="multiview">
+          <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
+              class="icon">
+              <path d="M3 3h8v8H3V3zm10 0h8v8h-8V3zM3 13h8v8H3v-8zm10 0h8v8h-8v-8z" />
+            </svg></span>
+          <span>Multi-telas</span>
         </a>
         <a href="#" class="nav-link" data-page="guide">
           <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
@@ -284,6 +291,56 @@
               </div>
             </div>
           </section>
+        </div>
+      </div>
+
+      <!-- Multi-view Page -->
+      <div id="page-multiview" class="page">
+        <div class="multiview-shell">
+          <header class="multiview-header">
+            <div>
+              <h2>Multi-telas</h2>
+              <p>Assista a até quatro canais ao vivo. Apenas uma tela reproduz áudio por vez.</p>
+            </div>
+            <div class="multiview-header-actions">
+              <div class="multiview-screen-count" aria-label="Quantidade de telas">
+                <span>Telas</span>
+                <button data-screen-count="1" aria-label="Usar uma tela">1</button>
+                <button data-screen-count="2" aria-label="Usar duas telas">2</button>
+                <button data-screen-count="3" aria-label="Usar três telas">3</button>
+                <button data-screen-count="4" aria-label="Usar quatro telas">4</button>
+              </div>
+              <button class="btn btn-secondary" id="multiview-stop-all">Parar todas</button>
+            </div>
+          </header>
+
+          <div class="multiview-connection-warning">
+            Cada tela utiliza uma conexão do seu provedor. Seu plano precisa permitir transmissões simultâneas.
+          </div>
+
+          <div class="multiview-grid" id="multiview-grid"></div>
+        </div>
+
+        <div class="multiview-picker" id="multiview-picker" aria-hidden="true">
+          <div class="multiview-picker-panel" role="dialog" aria-modal="true" aria-labelledby="multiview-picker-title">
+            <div class="multiview-picker-header">
+              <div>
+                <h3 id="multiview-picker-title">Escolher canal</h3>
+                <p id="multiview-picker-count">Carregando canais...</p>
+              </div>
+              <button class="multiview-icon-btn" id="multiview-picker-close" aria-label="Fechar">&times;</button>
+            </div>
+            <div class="multiview-picker-filters">
+              <select id="multiview-source-filter" class="source-select">
+                <option value="">Todas as fontes</option>
+              </select>
+              <select id="multiview-group-filter" class="source-select">
+                <option value="">Todas as categorias</option>
+              </select>
+              <input id="multiview-search" class="search-input" type="search" placeholder="Buscar canal...">
+            </div>
+            <div class="multiview-channel-results" id="multiview-channel-results"></div>
+          </div>
         </div>
       </div>
 
@@ -1103,12 +1160,13 @@
   <script src="/js/components/EpgGuide.js?v=2"></script>
   <script src="/js/pages/HomePage.js?v=2"></script>
   <script src="/js/pages/LivePage.js?v=2"></script>
+  <script src="/js/pages/MultiViewPage.js?v=2"></script>
   <script src="/js/pages/Guide.js?v=2"></script>
   <script src="/js/pages/MoviesPage.js?v=4"></script>
   <script src="/js/pages/SeriesPage.js?v=1"></script>
   <script src="/js/pages/Settings.js?v=2"></script>
   <script src="/js/pages/WatchPage.js?v=1"></script>
-  <script src="/js/app.js?v=4"></script>
+  <script src="/js/app.js?v=5"></script>
   <script>
     // Check for SSO token in URL
     (function () {

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -36,8 +36,10 @@ const API = {
         }
 
         if (!response.ok) {
-            // If unauthorized, redirect to login
-            if (response.status === 401) {
+            // Only an authentication failure issued by NodeCast invalidates the
+            // local session. A provider may also return 401 for a stream; that
+            // error must not sign the user out of the application.
+            if (response.status === 401 && result.code === 'AUTH_REQUIRED') {
                 localStorage.removeItem('authToken');
                 window.location.href = '/login.html';
                 return;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -17,6 +17,7 @@ class App {
         // Initialize page controllers
         this.pages.home = new HomePage(this);
         this.pages.live = new LivePage(this);
+        this.pages.multiview = new MultiViewPage(this);
         this.pages.guide = new GuidePage(this);
         this.pages.movies = new MoviesPage(this);
         this.pages.series = new SeriesPage(this);

--- a/public/js/components/ChannelList.js
+++ b/public/js/components/ChannelList.js
@@ -33,12 +33,7 @@ class ChannelList {
      * Only proxies HTTP URLs when on HTTPS page
      */
     getProxiedImageUrl(url) {
-        if (!url || url.length === 0) return '/img/placeholder.png';
-        // Only proxy if we're on HTTPS and the image is HTTP
-        if (window.location.protocol === 'https:' && url.startsWith('http://')) {
-            return `/api/proxy/image?url=${encodeURIComponent(url)}`;
-        }
-        return url;
+        return Security.imageUrl(url);
     }
 
     /**
@@ -470,9 +465,9 @@ class ChannelList {
 
             html += `
         <div class="channel-group">
-          <div class="group-header ${this.collapsedGroups.has(groupName) ? 'collapsed' : ''} ${isFavoritesGroup ? 'favorites-group' : ''}" data-group="${groupName}">
+          <div class="group-header ${this.collapsedGroups.has(groupName) ? 'collapsed' : ''} ${isFavoritesGroup ? 'favorites-group' : ''}" data-group="${this.escapeHtml(groupName)}">
             <span class="group-toggle">${Icons.chevronDown}</span>
-            <span class="group-name">${groupName}</span>
+            <span class="group-name">${this.escapeHtml(groupName)}</span>
             <span class="group-count">${visibleChannels.length}</span>
           </div>
           <div class="group-channels">
@@ -502,15 +497,14 @@ class ChannelList {
 
                 html += `
           <div class="channel-item ${isActive ? 'active' : ''} ${isRenderActive ? 'nav-active' : ''} ${channelHidden ? 'hidden' : ''}" 
-               data-channel-id="${channel.id}"
-               data-source-id="${channel.sourceId}"
-               data-source-type="${channel.sourceType}"
-               data-stream-id="${channel.streamId || ''}"
-               data-url="${channel.url || ''}"
-               data-render-id="${renderId}"
-               data-render-group="${renderGroup}">
-            <img class="channel-logo" src="${this.getProxiedImageUrl(channel.tvgLogo)}" 
-                 alt="" onerror="this.onerror=null;this.src='/img/placeholder.png'">
+               data-channel-id="${this.escapeHtml(String(channel.id))}"
+               data-source-id="${this.escapeHtml(String(channel.sourceId))}"
+               data-source-type="${this.escapeHtml(channel.sourceType)}"
+               data-stream-id="${this.escapeHtml(String(channel.streamId || ''))}"
+               data-url="${this.escapeHtml(channel.url || '')}"
+               data-render-id="${this.escapeHtml(renderId)}"
+               data-render-group="${this.escapeHtml(renderGroup)}">
+            <img class="channel-logo" src="${this.escapeHtml(this.getProxiedImageUrl(channel.tvgLogo))}" alt="">
             <div class="channel-info">
               <div class="channel-name">${this.escapeHtml(channel.name)}</div>
               <div class="channel-program">${this.escapeHtml(this.getProgramInfo(channel) || '')}</div>
@@ -615,15 +609,14 @@ class ChannelList {
 
             html += `
           <div class="channel-item ${isActive ? 'active' : ''} ${channelHidden ? 'hidden' : ''}" 
-               data-channel-id="${channel.id}"
-               data-source-id="${channel.sourceId}"
-               data-source-type="${channel.sourceType}"
-               data-stream-id="${channel.streamId || ''}"
-               data-url="${channel.url || ''}"
-               data-render-id="${renderId}"
-               data-render-group="${renderGroup}">
-            <img class="channel-logo" src="${this.getProxiedImageUrl(channel.tvgLogo)}" 
-                 alt="" onerror="this.onerror=null;this.src='/img/placeholder.png'">
+               data-channel-id="${this.escapeHtml(String(channel.id))}"
+               data-source-id="${this.escapeHtml(String(channel.sourceId))}"
+               data-source-type="${this.escapeHtml(channel.sourceType)}"
+               data-stream-id="${this.escapeHtml(String(channel.streamId || ''))}"
+               data-url="${this.escapeHtml(channel.url || '')}"
+               data-render-id="${this.escapeHtml(renderId)}"
+               data-render-group="${this.escapeHtml(renderGroup)}">
+            <img class="channel-logo" src="${this.escapeHtml(this.getProxiedImageUrl(channel.tvgLogo))}" alt="">
             <div class="channel-info">
               <div class="channel-name">${this.escapeHtml(channel.name)}</div>
               <div class="channel-program">${this.escapeHtml(this.getProgramInfo(channel) || '')}</div>
@@ -733,7 +726,7 @@ class ChannelList {
             this.render();
         } catch (err) {
             console.error('Error loading channels:', err);
-            this.container.innerHTML = `<div class="empty-state"><p>Error loading channels</p><p class="hint">${err.message}</p></div>`;
+            this.container.innerHTML = `<div class="empty-state"><p>Error loading channels</p><p class="hint">${this.escapeHtml(err.message)}</p></div>`;
         } finally {
             this.isLoading = false;
         }
@@ -1040,11 +1033,10 @@ class ChannelList {
         div.dataset.url = channel.url || '';
 
         div.innerHTML = `
-            <img class="channel-logo" src="${this.getProxiedImageUrl(channel.tvgLogo)}" 
-                 alt="" onerror="this.onerror=null;this.src='/img/placeholder.png'">
+            <img class="channel-logo" src="${this.escapeHtml(this.getProxiedImageUrl(channel.tvgLogo))}" alt="">
             <div class="channel-info">
               <div class="channel-name">${this.escapeHtml(channel.name)}</div>
-              <div class="channel-program">${this.getProgramInfo(channel) || ''}</div>
+              <div class="channel-program">${this.escapeHtml(this.getProgramInfo(channel) || '')}</div>
             </div>
             <button class="favorite-btn active" title="Remove from Favorites">
               ❤️
@@ -1293,11 +1285,10 @@ class ChannelList {
         modalBody.innerHTML = `
             <div class="epg-info-modal">
                 <div class="channel-details">
-                    <img class="channel-logo" src="${this.getProxiedImageUrl(channel.tvgLogo)}" 
-                         onerror="this.onerror=null;this.src='/img/placeholder.png'" />
+                    <img class="channel-logo" src="${this.escapeHtml(this.getProxiedImageUrl(channel.tvgLogo))}" />
                     <div class="channel-meta">
                         <p><strong>Group:</strong> ${this.escapeHtml(channel.groupTitle || 'Uncategorized')}</p>
-                        <p><strong>Source:</strong> ${channel.sourceType}</p>
+                        <p><strong>Source:</strong> ${this.escapeHtml(channel.sourceType)}</p>
                         ${channel.tvgId ? `<p><strong>TVG ID:</strong> ${this.escapeHtml(channel.tvgId)}</p>` : ''}
                     </div>
                 </div>

--- a/public/js/components/EpgGuide.js
+++ b/public/js/components/EpgGuide.js
@@ -43,12 +43,7 @@ class EpgGuide {
      * Only proxies HTTP URLs when on HTTPS page
      */
     getProxiedImageUrl(url) {
-        if (!url || url.length === 0) return '/img/placeholder.png';
-        // Only proxy if we're on HTTPS and the image is HTTP
-        if (window.location.protocol === 'https:' && url.startsWith('http://')) {
-            return `/api/proxy/image?url=${encodeURIComponent(url)}`;
-        }
-        return url;
+        return Security.imageUrl(url);
     }
 
     init() {
@@ -186,7 +181,7 @@ class EpgGuide {
             this.container.innerHTML = `
         <div class="empty-state">
           <p>Error loading EPG</p>
-          <p class="hint">${err.message}</p>
+          <p class="hint">${Security.escapeHtml(err.message)}</p>
         </div>
       `;
         }
@@ -212,9 +207,7 @@ class EpgGuide {
         // Load EPG from ALL sources in parallel
         const fetchPromises = sources.map(async (source) => {
             try {
-                const response = await fetch(`/api/proxy/epg/${source.id}${queryParams}`);
-                if (!response.ok) throw new Error(`Status ${response.status}`);
-                return await response.json();
+                return await API.request('GET', `/proxy/epg/${source.id}${queryParams}`);
             } catch (e) {
                 console.warn(`Failed to load EPG for source ${source.name}:`, e);
                 return null;
@@ -387,16 +380,17 @@ class EpgGuide {
         if (this.groupSelect && this._lastGroupsKey !== groupsKey) {
             this._lastGroupsKey = groupsKey;
             const currentValue = this.selectedGroup;
-            let optionsHtml = '';
-
-            if (hasFavorites) {
-                optionsHtml += `<option value="Favorites" ${currentValue === 'Favorites' ? 'selected' : ''}>Favorites</option>`;
-            }
-
-            optionsHtml += `<option value="" ${currentValue === '' ? 'selected' : ''}>All Groups</option>`;
-            optionsHtml += groups.map(g => `<option value="${g}" ${g === currentValue ? 'selected' : ''}>${g}</option>`).join('');
-
-            this.groupSelect.innerHTML = optionsHtml;
+            this.groupSelect.replaceChildren();
+            const addOption = (value, label) => {
+                const option = document.createElement('option');
+                option.value = value;
+                option.textContent = label;
+                option.selected = value === currentValue;
+                this.groupSelect.appendChild(option);
+            };
+            if (hasFavorites) addOption('Favorites', 'Favorites');
+            addOption('', 'All Groups');
+            groups.forEach(group => addOption(group, group));
         } else if (this.groupSelect) {
             // Just update the selected value without rebuilding
             this.groupSelect.value = this.selectedGroup;
@@ -595,9 +589,8 @@ class EpgGuide {
             <button class="favorite-btn ${isFavorite ? 'active' : ''}" title="${isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}">
               ${isFavorite ? Icons.favorite : Icons.favoriteOutline}
             </button>
-            <img class="epg-channel-logo" src="${logo}" 
-                 alt="" onerror="this.onerror=null;this.src='/img/placeholder.png'">
-            <span class="epg-channel-name">${name}</span>
+            <img class="epg-channel-logo" src="${Security.escapeAttribute(logo)}" alt="">
+            <span class="epg-channel-name">${Security.escapeHtml(name)}</span>
             <div class="resize-handle"></div>
           </div>
           <div class="epg-programs">
@@ -806,11 +799,11 @@ class EpgGuide {
             html += `
         <div class="epg-program ${isCurrent ? 'current' : ''}" 
              style="width: ${width}px;"
-             data-title="${prog.title || ''}"
-             data-description="${prog.description || ''}"
-             data-start="${prog.start}"
-             data-stop="${prog.stop}">
-          <div class="epg-program-title">${prog.title || 'Unknown'}</div>
+             data-title="${Security.escapeAttribute(prog.title || '')}"
+             data-description="${Security.escapeAttribute(prog.description || '')}"
+             data-start="${Security.escapeAttribute(prog.start)}"
+             data-stop="${Security.escapeAttribute(prog.stop)}">
+          <div class="epg-program-title">${Security.escapeHtml(prog.title || 'Unknown')}</div>
           <div class="epg-program-time">
             ${new Date(prog.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
           </div>
@@ -899,7 +892,7 @@ class EpgGuide {
         body.innerHTML = `
       <p><strong>Time:</strong> ${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} - ${stop.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</p>
       <p><strong>Description:</strong></p>
-      <p>${data.description || 'No description available'}</p>
+      <p>${Security.escapeHtml(data.description || 'No description available')}</p>
     `;
 
         footer.innerHTML = '<button class="btn btn-secondary" id="modal-close">Close</button>';

--- a/public/js/components/SourceManager.js
+++ b/public/js/components/SourceManager.js
@@ -137,6 +137,9 @@ class SourceManager {
         <div class="source-info">
           <div class="source-name">${source.name}</div>
           <div class="source-url">${source.url}</div>
+          ${type === 'xtream' && source.fallbackUrls?.length
+                ? `<div class="hint">${source.fallbackUrls.length} alternative DNS configured</div>`
+                : ''}
         </div>
         <div class="source-actions">
           <button class="btn btn-sm btn-secondary" data-action="refresh" title="Refresh Data">${Icons.refresh}</button>
@@ -240,6 +243,7 @@ class SourceManager {
     `;
 
         if (type === 'xtream') {
+            const fallbackUrls = Array.isArray(source.fallbackUrls) ? source.fallbackUrls.join('\n') : '';
             return `
         ${nameField}
         ${urlField}
@@ -251,6 +255,12 @@ class SourceManager {
           <label for="source-password">Password</label>
           <input type="password" id="source-password" class="form-input" 
                  value="${source.password && !source.password.includes('•') ? source.password : ''}">
+        </div>
+        <div class="form-group">
+          <label for="source-fallback-urls">Alternative DNS URLs</label>
+          <textarea id="source-fallback-urls" class="form-input" rows="3"
+                    placeholder="http://alternative-server.com:port">${fallbackUrls}</textarea>
+          <p class="hint">One URL per line. They are tried automatically if the active DNS fails.</p>
         </div>
       `;
         }
@@ -266,6 +276,8 @@ class SourceManager {
         const url = document.getElementById('source-url').value.trim();
         const username = document.getElementById('source-username')?.value.trim() || null;
         const password = document.getElementById('source-password')?.value.trim() || null;
+        const fallbackUrls = document.getElementById('source-fallback-urls')?.value
+            .split(/\r?\n/).map(value => value.trim()).filter(Boolean) || [];
 
         if (!name || !url) {
             alert('Name and URL are required');
@@ -295,7 +307,7 @@ class SourceManager {
                 }
             }
 
-            await API.sources.create({ type, name, url, username, password });
+            await API.sources.create({ type, name, url, username, password, fallbackUrls });
             document.getElementById('modal').classList.remove('active');
             await this.loadSources();
 
@@ -317,6 +329,8 @@ class SourceManager {
         const url = document.getElementById('source-url').value.trim();
         const username = document.getElementById('source-username')?.value.trim();
         const password = document.getElementById('source-password')?.value.trim();
+        const fallbackUrls = document.getElementById('source-fallback-urls')?.value
+            .split(/\r?\n/).map(value => value.trim()).filter(Boolean) || [];
 
         if (!name || !url) {
             alert('Name and URL are required');
@@ -328,6 +342,7 @@ class SourceManager {
             if (type === 'xtream') {
                 data.username = username;
                 if (password) data.password = password;
+                data.fallbackUrls = fallbackUrls;
             }
 
             await API.sources.update(id, data);

--- a/public/js/components/SourceManager.js
+++ b/public/js/components/SourceManager.js
@@ -132,11 +132,11 @@ class SourceManager {
         const icons = { xtream: Icons.live, m3u: Icons.guide, epg: Icons.series };
 
         container.innerHTML = sources.map(source => `
-      <div class="source-item ${source.enabled ? '' : 'disabled'}" data-id="${source.id}">
+      <div class="source-item ${source.enabled ? '' : 'disabled'}" data-id="${this.escapeHtml(String(source.id))}">
         <span class="source-icon">${icons[type]}</span>
         <div class="source-info">
-          <div class="source-name">${source.name}</div>
-          <div class="source-url">${source.url}</div>
+          <div class="source-name">${this.escapeHtml(source.name)}</div>
+          <div class="source-url">${this.escapeHtml(source.url)}</div>
           ${type === 'xtream' && source.fallbackUrls?.length
                 ? `<div class="hint">${source.fallbackUrls.length} alternative DNS configured</div>`
                 : ''}
@@ -229,7 +229,7 @@ class SourceManager {
         const nameField = `
       <div class="form-group">
         <label for="source-name">Name</label>
-        <input type="text" id="source-name" class="form-input" placeholder="My Source" value="${source.name || ''}">
+        <input type="text" id="source-name" class="form-input" placeholder="My Source" value="${this.escapeHtml(source.name || '')}">
       </div>
     `;
 
@@ -238,7 +238,7 @@ class SourceManager {
         <label for="source-url">${type === 'xtream' ? 'Server URL' : 'URL'}</label>
         <input type="text" id="source-url" class="form-input" 
                placeholder="${type === 'xtream' ? 'http://server.com:port' : 'https://example.com/playlist.m3u'}" 
-               value="${source.url || ''}">
+               value="${this.escapeHtml(source.url || '')}">
       </div>
     `;
 
@@ -249,17 +249,17 @@ class SourceManager {
         ${urlField}
         <div class="form-group">
           <label for="source-username">Username</label>
-          <input type="text" id="source-username" class="form-input" value="${source.username || ''}">
+          <input type="text" id="source-username" class="form-input" value="${this.escapeHtml(source.username || '')}">
         </div>
         <div class="form-group">
           <label for="source-password">Password</label>
           <input type="password" id="source-password" class="form-input" 
-                 value="${source.password && !source.password.includes('•') ? source.password : ''}">
+                 value="">
         </div>
         <div class="form-group">
           <label for="source-fallback-urls">Alternative DNS URLs</label>
           <textarea id="source-fallback-urls" class="form-input" rows="3"
-                    placeholder="http://alternative-server.com:port">${fallbackUrls}</textarea>
+                    placeholder="http://alternative-server.com:port">${this.escapeHtml(fallbackUrls)}</textarea>
           <p class="hint">One URL per line. They are tried automatically if the active DNS fails.</p>
         </div>
       `;
@@ -600,7 +600,10 @@ class SourceManager {
             select.innerHTML = '<option value="">Select a source...</option>';
 
             sources.filter(s => s.type === 'xtream' || s.type === 'm3u').forEach(source => {
-                select.innerHTML += `<option value="${source.id}">${source.name} (${source.type})</option>`;
+                const option = document.createElement('option');
+                option.value = source.id;
+                option.textContent = `${source.name} (${source.type})`;
+                select.appendChild(option);
             });
         } catch (err) {
             console.error('Error loading content sources:', err);
@@ -761,9 +764,9 @@ class SourceManager {
                 return `
                     <label class="checkbox-label channel-item" title="${this.escapeHtml(item.name)}">
                         <input type="checkbox" class="channel-checkbox" 
-                               data-type="${item.type}" 
-                               data-id="${item.id}" 
-                               data-source-id="${this.treeData.sourceId}" 
+                               data-type="${this.escapeHtml(item.type)}"
+                               data-id="${this.escapeHtml(item.id)}"
+                               data-source-id="${this.escapeHtml(this.treeData.sourceId)}"
                                ${!itemHidden ? 'checked' : ''}>
                         <span class="channel-name">${this.escapeHtml(item.name)}</span>
                     </label>`;
@@ -775,11 +778,11 @@ class SourceManager {
             <div class="content-group ${isExpanded ? '' : 'collapsed'}" data-group-id="${this.escapeHtml(group.id)}">
                 <div class="content-group-header">
                     <span class="group-expander">${Icons.chevronDown}</span>
-                    <label class="checkbox-label" onclick="event.stopPropagation()">
+                    <label class="checkbox-label">
                         <input type="checkbox" class="group-checkbox" 
                                data-type="group" 
                                data-id="${this.escapeHtml(group.name)}" 
-                               data-source-id="${this.treeData.sourceId}" 
+                               data-source-id="${this.escapeHtml(this.treeData.sourceId)}"
                                ${checked ? 'checked' : ''}>
                         <span class="group-name">${this.escapeHtml(group.name)} (${group.items.length})</span>
                     </label>

--- a/public/js/components/VideoPlayer.js
+++ b/public/js/components/VideoPlayer.js
@@ -1030,11 +1030,8 @@ class VideoPlayer {
             // 1. User enabled "Force Proxy" in settings
             // 2. Known CORS-restricted domains (like Pluto TV)
             // Note: Xtream sources are NOT auto-proxied because many providers IP-lock streams
-            const proxyRequiredDomains = ['pluto.tv'];
-            const needsProxy = this.settings.forceProxy || proxyRequiredDomains.some(domain => streamUrl.includes(domain));
-
-            this.isUsingProxy = needsProxy;
-            const finalUrl = needsProxy ? this.getProxiedUrl(streamUrl) : streamUrl;
+            this.isUsingProxy = true;
+            const finalUrl = this.getProxiedUrl(streamUrl);
 
             // Detect if this is likely an HLS stream (has .m3u8 in URL)
             const looksLikeHls = finalUrl.includes('.m3u8') || finalUrl.includes('m3u8');
@@ -1354,7 +1351,9 @@ class VideoPlayer {
      * Get proxied URL for a stream
      */
     getProxiedUrl(url) {
-        return `/api/proxy/stream?url=${encodeURIComponent(url)}`;
+        if (typeof url === 'string' && url.startsWith('/api/')) return url;
+        const safe = Security.safeUrl(url);
+        return safe ? `/api/proxy/stream?url=${encodeURIComponent(safe)}` : '';
     }
 
     /**
@@ -1449,7 +1448,7 @@ class VideoPlayer {
      */
     showError(message) {
         this.overlay.classList.remove('hidden');
-        this.overlay.querySelector('.overlay-content').innerHTML = `<p style="color: var(--color-error);">${message}</p>`;
+        this.overlay.querySelector('.overlay-content').innerHTML = `<p style="color: var(--color-error);">${Security.escapeHtml(message)}</p>`;
     }
 
     /**

--- a/public/js/pages/HomePage.js
+++ b/public/js/pages/HomePage.js
@@ -251,14 +251,13 @@ class HomePage {
     }
 
     createChannelTile(channel) {
-        const logo = channel.tvgLogo || '/img/placeholder.png';
-        const logoUrl = logo.startsWith('http') ? `/api/proxy/image?url=${encodeURIComponent(logo)}` : logo;
-        const name = channel.name || 'Unknown';
+        const logoUrl = Security.imageUrl(channel.tvgLogo);
+        const name = Security.escapeHtml(channel.name || 'Unknown');
 
         return `
-            <div class="channel-tile" data-channel-id="${channel.id}" data-source-id="${channel.sourceId}">
+            <div class="channel-tile" data-channel-id="${Security.escapeAttribute(channel.id)}" data-source-id="${Security.escapeAttribute(channel.sourceId)}">
                 <div class="tile-logo">
-                    <img src="${logoUrl}" alt="${name}" loading="lazy" onerror="this.onerror=null;this.src='/img/placeholder.png'">
+                    <img src="${Security.escapeAttribute(logoUrl)}" alt="${name}" loading="lazy">
                 </div>
                 <div class="tile-name" title="${name}">${name}</div>
             </div>
@@ -411,13 +410,14 @@ class HomePage {
         const percent = Math.min(100, Math.round((progress / duration) * 100));
 
         // Proxy the poster if it's an external URL
-        const poster = data.poster || '/img/poster-placeholder.jpg';
-        const posterUrl = poster.startsWith('http') ? `/api/proxy/image?url=${encodeURIComponent(poster)}` : poster;
+        const posterUrl = Security.imageUrl(data.poster, '/img/poster-placeholder.jpg');
+        const title = Security.escapeHtml(item.name || data.title || 'Unknown Title');
+        const subtitle = Security.escapeHtml(data.subtitle || (type === 'movie' ? 'Movie' : 'Series'));
 
         return `
-            <div class="dashboard-card" data-id="${item_id}" data-type="${type}">
+            <div class="dashboard-card" data-id="${Security.escapeAttribute(item_id)}" data-type="${Security.escapeAttribute(type)}">
                 <div class="card-image">
-                    <img src="${posterUrl}" alt="${data.title || item.name}" loading="lazy" onerror="this.onerror=null;this.src='/img/poster-placeholder.jpg'">
+                    <img src="${Security.escapeAttribute(posterUrl)}" alt="${title}" data-fallback="/img/poster-placeholder.jpg" loading="lazy">
                     <div class="progress-bar-container">
                         <div class="progress-bar" style="width: ${percent}%"></div>
                     </div>
@@ -426,8 +426,8 @@ class HomePage {
                     </div>
                 </div>
                 <div class="card-info">
-                    <div class="card-title" title="${item.name || data.title}">${item.name || data.title || 'Unknown Title'}</div>
-                    <div class="card-subtitle">${data.subtitle || (type === 'movie' ? 'Movie' : 'Series')}</div>
+                    <div class="card-title" title="${title}">${title}</div>
+                    <div class="card-subtitle">${subtitle}</div>
                 </div>
             </div>
         `;
@@ -436,20 +436,21 @@ class HomePage {
     createRecentCard(item) {
         const { data, item_id } = item;
         const type = item.type || item.item_type;
-        const poster = item.stream_icon || data.poster || '/img/poster-placeholder.jpg';
-        const posterUrl = poster.startsWith('http') ? `/api/proxy/image?url=${encodeURIComponent(poster)}` : poster;
+        const posterUrl = Security.imageUrl(item.stream_icon || data.poster, '/img/poster-placeholder.jpg');
+        const title = Security.escapeHtml(item.name || (data && data.title) || 'Unknown Title');
+        const subtitle = Security.escapeHtml((data && data.subtitle) || (type === 'movie' ? 'Movie' : 'Series'));
 
         return `
-            <div class="dashboard-card" data-id="${item_id}" data-type="${type}">
+            <div class="dashboard-card" data-id="${Security.escapeAttribute(item_id)}" data-type="${Security.escapeAttribute(type)}">
                 <div class="card-image">
-                    <img src="${posterUrl}" alt="${item.name}" loading="lazy" onerror="this.onerror=null;this.src='/img/poster-placeholder.jpg'">
+                    <img src="${Security.escapeAttribute(posterUrl)}" alt="${title}" data-fallback="/img/poster-placeholder.jpg" loading="lazy">
                     <div class="play-icon-overlay">
                         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
                     </div>
                 </div>
                 <div class="card-info">
-                    <div class="card-title" title="${item.name || (data && data.title)}">${item.name || (data && data.title) || 'Unknown Title'}</div>
-                    <div class="card-subtitle">${(data && data.subtitle) || (type === 'movie' ? 'Movie' : 'Series')}</div>
+                    <div class="card-title" title="${title}">${title}</div>
+                    <div class="card-subtitle">${subtitle}</div>
                 </div>
             </div>
         `;

--- a/public/js/pages/MoviesPage.js
+++ b/public/js/pages/MoviesPage.js
@@ -278,16 +278,16 @@ class MoviesPage {
             card.dataset.movieId = movie.stream_id;
             card.dataset.sourceId = movie.sourceId;
 
-            const poster = movie.stream_icon || movie.cover || '/img/placeholder.png';
-            const year = movie.year || movie.releaseDate?.substring(0, 4) || '';
-            const rating = movie.rating ? `${Icons.star} ${movie.rating}` : '';
+            const poster = Security.imageUrl(movie.stream_icon || movie.cover);
+            const name = Security.escapeHtml(movie.name || 'Unknown');
+            const year = Security.escapeHtml(movie.year || movie.releaseDate?.substring(0, 4) || '');
+            const rating = movie.rating ? `${Icons.star} ${Security.escapeHtml(movie.rating)}` : '';
 
             const isFav = this.favoriteIds.has(`${movie.sourceId}:${movie.stream_id}`);
 
             card.innerHTML = `
                 <div class="movie-poster">
-                    <img src="${poster}" alt="${movie.name}" 
-                         onerror="this.onerror=null;this.src='/img/placeholder.png'" loading="lazy">
+                    <img src="${Security.escapeAttribute(poster)}" alt="${name}" loading="lazy">
                     <div class="movie-play-overlay">
                         <span class="play-icon">${Icons.play}</span>
                     </div>
@@ -296,7 +296,7 @@ class MoviesPage {
                     </button>
                 </div>
                 <div class="movie-info">
-                    <div class="movie-title">${movie.name}</div>
+                    <div class="movie-title">${name}</div>
                     <div class="movie-meta">
                         ${year ? `<span>${year}</span>` : ''}
                         ${rating ? `<span>${rating}</span>` : ''}

--- a/public/js/pages/MultiViewPage.js
+++ b/public/js/pages/MultiViewPage.js
@@ -214,7 +214,7 @@ class MultiViewPage {
     populateSourceFilter() {
         if (!this.sourceFilter) return;
         this.sourceFilter.innerHTML = '<option value="">Todas as fontes</option>' + this.sources.map(source =>
-            `<option value="${source.id}">${this.escapeHtml(source.name)}</option>`
+            `<option value="${this.escapeHtml(source.id)}">${this.escapeHtml(source.name)}</option>`
         ).join('');
     }
 
@@ -283,8 +283,7 @@ class MultiViewPage {
 
         this.results.innerHTML = visible.map(channel => `
             <button class="multiview-channel-option" data-channel-key="${this.escapeHtml(channel.key)}">
-                <img src="${this.escapeHtml(channel.logo || '/img/placeholder.png')}" alt=""
-                     onerror="this.onerror=null;this.src='/img/placeholder.png'">
+                <img src="${this.escapeHtml(Security.imageUrl(channel.logo))}" alt="">
                 <span>
                     <strong>${this.escapeHtml(channel.name)}</strong>
                     <small>${this.escapeHtml(channel.group)} · ${this.escapeHtml(channel.sourceName)}</small>
@@ -334,8 +333,7 @@ class MultiViewPage {
             video.volume = 1;
             video.onerror = () => this.showTileError(slotIndex, 'Não foi possível reproduzir este canal.');
 
-            const shouldProxy = Boolean(this.app.player?.settings?.forceProxy);
-            const initialUrl = shouldProxy ? this.getProxiedUrl(streamUrl) : streamUrl;
+            const initialUrl = this.getProxiedUrl(streamUrl);
             const looksLikeHls = streamUrl.includes('.m3u8') || streamUrl.toLowerCase().includes('m3u8');
 
             if (looksLikeHls && window.Hls?.isSupported()) {
@@ -347,7 +345,7 @@ class MultiViewPage {
                     fragLoadingMaxRetry: 3
                 });
                 slot.hls = hls;
-                slot.proxyRetried = shouldProxy;
+                slot.proxyRetried = true;
                 hls.loadSource(initialUrl);
                 hls.attachMedia(video);
                 hls.on(Hls.Events.MANIFEST_PARSED, () => {
@@ -380,7 +378,9 @@ class MultiViewPage {
     }
 
     getProxiedUrl(url) {
-        return `/api/proxy/stream?url=${encodeURIComponent(url)}`;
+        if (typeof url === 'string' && url.startsWith('/api/')) return url;
+        const safe = Security.safeUrl(url);
+        return safe ? `/api/proxy/stream?url=${encodeURIComponent(safe)}` : '';
     }
 
     getTile(slotIndex) {

--- a/public/js/pages/MultiViewPage.js
+++ b/public/js/pages/MultiViewPage.js
@@ -57,6 +57,9 @@ class MultiViewPage {
                     <button class="multiview-control-btn" data-action="audio">Ativar som</button>
                     <button class="multiview-control-btn" data-action="fullscreen">Tela cheia</button>
                 </div>
+                <button class="multiview-exit-fullscreen" data-action="exit-fullscreen" aria-label="Sair da tela cheia">
+                    Sair da tela cheia
+                </button>
                 <div class="multiview-error"></div>
             </article>
         `).join('');
@@ -82,6 +85,9 @@ class MultiViewPage {
                     break;
                 case 'fullscreen':
                     this.enterFullscreen(slotIndex);
+                    break;
+                case 'exit-fullscreen':
+                    this.exitFullscreen();
                     break;
             }
         });
@@ -437,7 +443,15 @@ class MultiViewPage {
     enterFullscreen(slotIndex) {
         const tile = this.getTile(slotIndex);
         if (!tile || !this.slots[slotIndex].channel) return;
-        tile.requestFullscreen?.().catch(() => {});
+        const request = tile.requestFullscreen || tile.webkitRequestFullscreen;
+        if (!request) return;
+        Promise.resolve(request.call(tile)).catch(() => {});
+    }
+
+    exitFullscreen() {
+        const exit = document.exitFullscreen || document.webkitExitFullscreen;
+        if (!exit || (!document.fullscreenElement && !document.webkitFullscreenElement)) return;
+        Promise.resolve(exit.call(document)).catch(() => {});
     }
 
     stopSlot(slotIndex, clearChannel = false) {

--- a/public/js/pages/MultiViewPage.js
+++ b/public/js/pages/MultiViewPage.js
@@ -1,0 +1,466 @@
+/**
+ * Multi-view page: four independent live players with shared channel picker.
+ */
+class MultiViewPage {
+    constructor(app) {
+        this.app = app;
+        this.grid = document.getElementById('multiview-grid');
+        this.picker = document.getElementById('multiview-picker');
+        this.results = document.getElementById('multiview-channel-results');
+        this.sourceFilter = document.getElementById('multiview-source-filter');
+        this.groupFilter = document.getElementById('multiview-group-filter');
+        this.searchInput = document.getElementById('multiview-search');
+        this.sources = [];
+        this.channels = [];
+        this.channelMap = new Map();
+        this.activeSlot = null;
+        this.initialized = false;
+        this.loadingChannels = null;
+        const savedScreenCount = Number.parseInt(localStorage.getItem('nodecast_multiview_screen_count'), 10);
+        this.screenCount = savedScreenCount >= 1 && savedScreenCount <= 4 ? savedScreenCount : 4;
+        this.slots = Array.from({ length: 4 }, () => ({
+            hls: null,
+            channel: null,
+            generation: 0,
+            proxyRetried: false
+        }));
+
+        this.renderTiles();
+        this.bindEvents();
+    }
+
+    escapeHtml(value) {
+        const div = document.createElement('div');
+        div.textContent = value == null ? '' : String(value);
+        return div.innerHTML;
+    }
+
+    renderTiles() {
+        if (!this.grid) return;
+
+        this.grid.innerHTML = this.slots.map((_, index) => `
+            <article class="multiview-tile ${index >= this.screenCount ? 'is-hidden' : ''}" data-slot="${index}">
+                <video class="multiview-video" playsinline muted></video>
+                <div class="multiview-empty">
+                    <span class="multiview-slot-number">Tela ${index + 1}</span>
+                    <button class="btn btn-primary" data-action="choose">Escolher canal</button>
+                </div>
+                <div class="multiview-loading" aria-hidden="true">
+                    <div class="loading-spinner"></div>
+                </div>
+                <div class="multiview-tile-topbar">
+                    <div class="multiview-channel-title">Nenhum canal</div>
+                    <button class="multiview-icon-btn" data-action="close" title="Fechar canal">&times;</button>
+                </div>
+                <div class="multiview-tile-controls">
+                    <button class="multiview-control-btn" data-action="choose">Trocar</button>
+                    <button class="multiview-control-btn" data-action="audio">Ativar som</button>
+                    <button class="multiview-control-btn" data-action="fullscreen">Tela cheia</button>
+                </div>
+                <div class="multiview-error"></div>
+            </article>
+        `).join('');
+        this.applyScreenCount();
+    }
+
+    bindEvents() {
+        this.grid?.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-action]');
+            const tile = event.target.closest('.multiview-tile');
+            if (!button || !tile) return;
+
+            const slotIndex = Number(tile.dataset.slot);
+            switch (button.dataset.action) {
+                case 'choose':
+                    this.openPicker(slotIndex);
+                    break;
+                case 'close':
+                    this.stopSlot(slotIndex, true);
+                    break;
+                case 'audio':
+                    this.toggleAudio(slotIndex);
+                    break;
+                case 'fullscreen':
+                    this.enterFullscreen(slotIndex);
+                    break;
+            }
+        });
+
+        document.getElementById('multiview-stop-all')?.addEventListener('click', () => this.stopAll(true));
+        document.querySelector('.multiview-screen-count')?.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-screen-count]');
+            if (button) this.setScreenCount(Number(button.dataset.screenCount));
+        });
+        document.getElementById('multiview-picker-close')?.addEventListener('click', () => this.closePicker());
+        this.picker?.addEventListener('click', (event) => {
+            if (event.target === this.picker) this.closePicker();
+        });
+
+        this.sourceFilter?.addEventListener('change', () => {
+            this.updateGroupFilter();
+            this.renderPickerResults();
+        });
+        this.groupFilter?.addEventListener('change', () => this.renderPickerResults());
+        this.searchInput?.addEventListener('input', () => this.renderPickerResults());
+
+        this.results?.addEventListener('click', (event) => {
+            const item = event.target.closest('[data-channel-key]');
+            if (!item) return;
+            const channel = this.channelMap.get(item.dataset.channelKey);
+            if (channel && this.activeSlot !== null) {
+                const slotIndex = this.activeSlot;
+                this.closePicker();
+                this.playChannel(slotIndex, channel);
+            }
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && this.picker?.classList.contains('active')) {
+                this.closePicker();
+            }
+        });
+    }
+
+    async show() {
+        // Avoid hidden playback consuming provider connections.
+        this.app.player?.stop?.();
+        this.app.pages.watch?.stop?.();
+
+        if (!this.initialized) {
+            this.initialized = true;
+            await this.loadChannels();
+        }
+    }
+
+    hide() {
+        this.closePicker();
+        this.stopAll(true);
+    }
+
+    setScreenCount(count) {
+        if (!Number.isInteger(count) || count < 1 || count > 4 || count === this.screenCount) return;
+
+        if (count < this.screenCount) {
+            for (let index = count; index < this.slots.length; index += 1) {
+                this.stopSlot(index, true);
+            }
+        }
+
+        this.screenCount = count;
+        localStorage.setItem('nodecast_multiview_screen_count', String(count));
+        this.applyScreenCount();
+    }
+
+    applyScreenCount() {
+        if (!this.grid) return;
+        this.grid.classList.remove('screens-1', 'screens-2', 'screens-3', 'screens-4');
+        this.grid.classList.add(`screens-${this.screenCount}`);
+
+        this.slots.forEach((_slot, index) => {
+            this.getTile(index)?.classList.toggle('is-hidden', index >= this.screenCount);
+        });
+
+        document.querySelectorAll('[data-screen-count]').forEach(button => {
+            const active = Number(button.dataset.screenCount) === this.screenCount;
+            button.classList.toggle('active', active);
+            button.setAttribute('aria-pressed', String(active));
+        });
+    }
+
+    async loadChannels() {
+        if (this.loadingChannels) return this.loadingChannels;
+
+        this.loadingChannels = (async () => {
+            this.setPickerMessage('Carregando canais...');
+            this.sources = (await API.sources.getAll()).filter(source => source.enabled && ['xtream', 'm3u'].includes(source.type));
+
+            const sourceResults = await Promise.all(this.sources.map(async (source) => {
+                try {
+                    const [categories, streams] = await Promise.all([
+                        API.proxy.xtream.liveCategories(source.id),
+                        API.proxy.xtream.liveStreams(source.id)
+                    ]);
+                    const categoryNames = new Map(categories.map(category => [String(category.category_id), category.category_name]));
+
+                    return streams.map(stream => ({
+                        key: `${source.id}:${stream.stream_id}`,
+                        sourceId: source.id,
+                        sourceName: source.name,
+                        sourceType: source.type,
+                        streamId: stream.stream_id,
+                        name: stream.name || 'Canal sem nome',
+                        logo: stream.stream_icon || '',
+                        url: stream.stream_url || '',
+                        group: categoryNames.get(String(stream.category_id)) || 'Sem categoria'
+                    }));
+                } catch (error) {
+                    console.warn(`[MultiView] Falha ao carregar a fonte ${source.name}:`, error.message);
+                    return [];
+                }
+            }));
+
+            this.channels = sourceResults.flat().sort((a, b) => a.name.localeCompare(b.name));
+            this.channelMap = new Map(this.channels.map(channel => [channel.key, channel]));
+            this.populateSourceFilter();
+            this.updateGroupFilter();
+            this.renderPickerResults();
+        })().finally(() => {
+            this.loadingChannels = null;
+        });
+
+        return this.loadingChannels;
+    }
+
+    populateSourceFilter() {
+        if (!this.sourceFilter) return;
+        this.sourceFilter.innerHTML = '<option value="">Todas as fontes</option>' + this.sources.map(source =>
+            `<option value="${source.id}">${this.escapeHtml(source.name)}</option>`
+        ).join('');
+    }
+
+    updateGroupFilter() {
+        if (!this.groupFilter) return;
+        const sourceId = this.sourceFilter?.value || '';
+        const groups = [...new Set(this.channels
+            .filter(channel => !sourceId || String(channel.sourceId) === sourceId)
+            .map(channel => channel.group))]
+            .sort((a, b) => a.localeCompare(b));
+
+        const previousValue = this.groupFilter.value;
+        this.groupFilter.innerHTML = '<option value="">Todas as categorias</option>' + groups.map(group =>
+            `<option value="${this.escapeHtml(group)}">${this.escapeHtml(group)}</option>`
+        ).join('');
+        if (groups.includes(previousValue)) this.groupFilter.value = previousValue;
+    }
+
+    openPicker(slotIndex) {
+        this.activeSlot = slotIndex;
+        this.picker?.classList.add('active');
+        this.picker?.setAttribute('aria-hidden', 'false');
+        this.searchInput?.focus();
+
+        if (this.channels.length === 0) {
+            this.loadChannels();
+        } else {
+            this.renderPickerResults();
+        }
+    }
+
+    closePicker() {
+        this.picker?.classList.remove('active');
+        this.picker?.setAttribute('aria-hidden', 'true');
+        this.activeSlot = null;
+    }
+
+    getFilteredChannels() {
+        const sourceId = this.sourceFilter?.value || '';
+        const group = this.groupFilter?.value || '';
+        const query = (this.searchInput?.value || '').trim().toLocaleLowerCase();
+
+        return this.channels.filter(channel => {
+            if (sourceId && String(channel.sourceId) !== sourceId) return false;
+            if (group && channel.group !== group) return false;
+            if (query && !`${channel.name} ${channel.group}`.toLocaleLowerCase().includes(query)) return false;
+            return true;
+        });
+    }
+
+    renderPickerResults() {
+        if (!this.results) return;
+        const filtered = this.getFilteredChannels();
+        const visible = filtered.slice(0, 200);
+        const count = document.getElementById('multiview-picker-count');
+        if (count) {
+            count.textContent = filtered.length > visible.length
+                ? `${filtered.length.toLocaleString()} canais — refine a busca para ver mais`
+                : `${filtered.length.toLocaleString()} canais`;
+        }
+
+        if (visible.length === 0) {
+            this.setPickerMessage(this.channels.length ? 'Nenhum canal encontrado.' : 'Nenhum canal disponível.');
+            return;
+        }
+
+        this.results.innerHTML = visible.map(channel => `
+            <button class="multiview-channel-option" data-channel-key="${this.escapeHtml(channel.key)}">
+                <img src="${this.escapeHtml(channel.logo || '/img/placeholder.png')}" alt=""
+                     onerror="this.onerror=null;this.src='/img/placeholder.png'">
+                <span>
+                    <strong>${this.escapeHtml(channel.name)}</strong>
+                    <small>${this.escapeHtml(channel.group)} · ${this.escapeHtml(channel.sourceName)}</small>
+                </span>
+            </button>
+        `).join('');
+    }
+
+    setPickerMessage(message) {
+        if (this.results) {
+            this.results.innerHTML = `<div class="multiview-picker-empty">${this.escapeHtml(message)}</div>`;
+        }
+    }
+
+    async resolveStreamUrl(channel) {
+        if (channel.sourceType === 'xtream') {
+            const format = this.app.player?.settings?.streamFormat || 'm3u8';
+            const result = await API.proxy.xtream.getStreamUrl(
+                channel.sourceId,
+                channel.streamId,
+                'live',
+                format
+            );
+            return result.url;
+        }
+        return channel.url;
+    }
+
+    async playChannel(slotIndex, channel) {
+        this.stopSlot(slotIndex, true);
+        const slot = this.slots[slotIndex];
+        const generation = slot.generation;
+        slot.channel = channel;
+        slot.proxyRetried = false;
+        this.updateTile(slotIndex, 'loading');
+
+        try {
+            const streamUrl = await this.resolveStreamUrl(channel);
+            if (!streamUrl) throw new Error('O canal não possui uma URL de reprodução.');
+            if (slot.generation !== generation) return;
+
+            const tile = this.getTile(slotIndex);
+            const video = tile?.querySelector('video');
+            if (!video) return;
+
+            video.muted = true;
+            video.volume = 1;
+            video.onerror = () => this.showTileError(slotIndex, 'Não foi possível reproduzir este canal.');
+
+            const shouldProxy = Boolean(this.app.player?.settings?.forceProxy);
+            const initialUrl = shouldProxy ? this.getProxiedUrl(streamUrl) : streamUrl;
+            const looksLikeHls = streamUrl.includes('.m3u8') || streamUrl.toLowerCase().includes('m3u8');
+
+            if (looksLikeHls && window.Hls?.isSupported()) {
+                const hls = new Hls({
+                    enableWorker: true,
+                    lowLatencyMode: false,
+                    maxBufferLength: 20,
+                    manifestLoadingMaxRetry: 2,
+                    fragLoadingMaxRetry: 3
+                });
+                slot.hls = hls;
+                slot.proxyRetried = shouldProxy;
+                hls.loadSource(initialUrl);
+                hls.attachMedia(video);
+                hls.on(Hls.Events.MANIFEST_PARSED, () => {
+                    if (slot.generation !== generation) return;
+                    this.updateTile(slotIndex, 'playing');
+                    video.play().catch(error => {
+                        if (error.name !== 'AbortError') this.showTileError(slotIndex, 'Clique em ativar som ou tente novamente.');
+                    });
+                });
+                hls.on(Hls.Events.ERROR, (_event, data) => {
+                    if (!data.fatal || slot.generation !== generation) return;
+                    if (data.type === Hls.ErrorTypes.NETWORK_ERROR && !slot.proxyRetried) {
+                        slot.proxyRetried = true;
+                        hls.loadSource(this.getProxiedUrl(streamUrl));
+                        hls.startLoad();
+                        return;
+                    }
+                    this.showTileError(slotIndex, 'Falha no canal ou limite de conexões atingido.');
+                });
+            } else {
+                video.src = initialUrl;
+                await video.play();
+                if (slot.generation === generation) this.updateTile(slotIndex, 'playing');
+            }
+        } catch (error) {
+            if (slot.generation === generation) {
+                this.showTileError(slotIndex, error.message || 'Falha ao iniciar o canal.');
+            }
+        }
+    }
+
+    getProxiedUrl(url) {
+        return `/api/proxy/stream?url=${encodeURIComponent(url)}`;
+    }
+
+    getTile(slotIndex) {
+        return this.grid?.querySelector(`[data-slot="${slotIndex}"]`);
+    }
+
+    updateTile(slotIndex, state) {
+        const tile = this.getTile(slotIndex);
+        const slot = this.slots[slotIndex];
+        if (!tile) return;
+
+        tile.classList.toggle('has-channel', Boolean(slot.channel));
+        tile.classList.toggle('is-loading', state === 'loading');
+        tile.classList.toggle('has-error', state === 'error');
+        tile.querySelector('.multiview-channel-title').textContent = slot.channel?.name || 'Nenhum canal';
+        if (state !== 'error') tile.querySelector('.multiview-error').textContent = '';
+        this.updateAudioButtons();
+    }
+
+    showTileError(slotIndex, message) {
+        const tile = this.getTile(slotIndex);
+        if (!tile) return;
+        tile.querySelector('.multiview-error').textContent = message;
+        this.updateTile(slotIndex, 'error');
+    }
+
+    toggleAudio(slotIndex) {
+        const tile = this.getTile(slotIndex);
+        const video = tile?.querySelector('video');
+        if (!video || !this.slots[slotIndex].channel) return;
+
+        const shouldEnable = video.muted;
+        this.slots.forEach((_slot, index) => {
+            const otherVideo = this.getTile(index)?.querySelector('video');
+            if (otherVideo) otherVideo.muted = true;
+        });
+        video.muted = !shouldEnable;
+        if (shouldEnable) video.play().catch(() => {});
+        this.updateAudioButtons();
+    }
+
+    updateAudioButtons() {
+        this.slots.forEach((_slot, index) => {
+            const tile = this.getTile(index);
+            const video = tile?.querySelector('video');
+            const button = tile?.querySelector('[data-action="audio"]');
+            if (!video || !button) return;
+            const enabled = !video.muted && Boolean(this.slots[index].channel);
+            tile.classList.toggle('audio-active', enabled);
+            button.textContent = enabled ? 'Som ativo' : 'Ativar som';
+        });
+    }
+
+    enterFullscreen(slotIndex) {
+        const tile = this.getTile(slotIndex);
+        if (!tile || !this.slots[slotIndex].channel) return;
+        tile.requestFullscreen?.().catch(() => {});
+    }
+
+    stopSlot(slotIndex, clearChannel = false) {
+        const slot = this.slots[slotIndex];
+        slot.generation += 1;
+        slot.hls?.destroy();
+        slot.hls = null;
+
+        const video = this.getTile(slotIndex)?.querySelector('video');
+        if (video) {
+            video.pause();
+            video.removeAttribute('src');
+            video.load();
+            video.muted = true;
+        }
+
+        if (clearChannel) slot.channel = null;
+        this.updateTile(slotIndex, 'idle');
+    }
+
+    stopAll(clearChannels = false) {
+        this.slots.forEach((_slot, index) => this.stopSlot(index, clearChannels));
+    }
+}
+
+window.MultiViewPage = MultiViewPage;

--- a/public/js/pages/SeriesPage.js
+++ b/public/js/pages/SeriesPage.js
@@ -288,16 +288,16 @@ class SeriesPage {
             card.dataset.seriesId = series.series_id;
             card.dataset.sourceId = series.sourceId;
 
-            const poster = series.cover || '/img/placeholder.png';
-            const year = series.year || series.releaseDate?.substring(0, 4) || '';
-            const rating = series.rating ? `${Icons.star} ${series.rating}` : '';
+            const poster = Security.imageUrl(series.cover);
+            const name = Security.escapeHtml(series.name || 'Unknown');
+            const year = Security.escapeHtml(series.year || series.releaseDate?.substring(0, 4) || '');
+            const rating = series.rating ? `${Icons.star} ${Security.escapeHtml(series.rating)}` : '';
 
             const isFav = this.favoriteIds.has(`${series.sourceId}:${series.series_id}`);
 
             card.innerHTML = `
                 <div class="series-poster">
-                    <img src="${poster}" alt="${series.name}" 
-                         onerror="this.onerror=null;this.src='/img/placeholder.png'" loading="lazy">
+                    <img src="${Security.escapeAttribute(poster)}" alt="${name}" loading="lazy">
                     <div class="series-play-overlay">
                         <span class="play-icon">${Icons.play}</span>
                     </div>
@@ -306,7 +306,7 @@ class SeriesPage {
                     </button>
                 </div>
                 <div class="series-card-info">
-                    <div class="series-title">${series.name}</div>
+                    <div class="series-title">${name}</div>
                     <div class="series-meta">
                         ${year ? `<span>${year}</span>` : ''}
                         ${rating ? `<span>${rating}</span>` : ''}
@@ -350,7 +350,7 @@ class SeriesPage {
         this.detailsPanel.classList.remove('hidden');
 
         // Set header info
-        document.getElementById('series-poster').src = series.cover || '/img/placeholder.png';
+        document.getElementById('series-poster').src = Security.imageUrl(series.cover);
         document.getElementById('series-title').textContent = series.name;
         document.getElementById('series-plot').textContent = series.plot || '';
 
@@ -379,14 +379,14 @@ class SeriesPage {
                 <div class="season-group">
                     <div class="season-header">
                         <span class="season-expander">${Icons.chevronDown}</span>
-                        <span class="season-name">Season ${seasonNum} (${episodes.length} episodes)</span>
+                        <span class="season-name">Season ${Security.escapeHtml(seasonNum)} (${episodes.length} episodes)</span>
                     </div>
                     <div class="episode-list">
                         ${episodes.map(ep => `
-                            <div class="episode-item" data-episode-id="${ep.id}" data-source-id="${series.sourceId}" data-container="${ep.container_extension || 'mp4'}">
-                                <span class="episode-number">E${ep.episode_num}</span>
-                                <span class="episode-title">${ep.title || `Episode ${ep.episode_num}`}</span>
-                                <span class="episode-duration">${ep.duration || ''}</span>
+                            <div class="episode-item" data-episode-id="${Security.escapeAttribute(ep.id)}" data-source-id="${Security.escapeAttribute(series.sourceId)}" data-container="${Security.escapeAttribute(ep.container_extension || 'mp4')}">
+                                <span class="episode-number">E${Security.escapeHtml(ep.episode_num)}</span>
+                                <span class="episode-title">${Security.escapeHtml(ep.title || `Episode ${ep.episode_num}`)}</span>
+                                <span class="episode-duration">${Security.escapeHtml(ep.duration || '')}</span>
                             </div>
                         `).join('')}
                     </div>

--- a/public/js/pages/Settings.js
+++ b/public/js/pages/Settings.js
@@ -363,19 +363,31 @@ class SettingsPage {
                 <tr>
                     <td>
                         <div style="display:flex;align-items:center;gap:8px;">
-                            <strong>${user.username}</strong>
+                            <strong>${Security.escapeHtml(user.username)}</strong>
                             ${typeBadge}
                         </div>
                     </td>
-                    <td>${user.email || '<span class="hint">-</span>'}</td>
+                    <td>${user.email ? Security.escapeHtml(user.email) : '<span class="hint">-</span>'}</td>
                     <td>${roleBadge}</td>
                     <td>${user.createdAt ? new Date(user.createdAt).toLocaleDateString() : 'N/A'}</td>
                     <td>
-                        <button class="btn btn-sm btn-secondary" onclick="window.app.pages.settings.openEditUserModal(${user.id})">Edit</button>
-                        <button class="btn btn-sm btn-error" onclick="window.app.pages.settings.deleteUser(${user.id}, '${user.username}')">Delete</button>
+                        <button class="btn btn-sm btn-secondary" data-user-action="edit" data-user-id="${Security.escapeAttribute(user.id)}">Edit</button>
+                        <button class="btn btn-sm btn-error" data-user-action="delete" data-user-id="${Security.escapeAttribute(user.id)}">Delete</button>
                     </td>
                 </tr>
             `}).join('');
+
+            userList.querySelectorAll('[data-user-action]').forEach(button => {
+                const userId = Number(button.dataset.userId);
+                if (button.dataset.userAction === 'edit') {
+                    button.addEventListener('click', () => this.openEditUserModal(userId));
+                } else {
+                    button.addEventListener('click', () => {
+                        const user = this.users.find(item => Number(item.id) === userId);
+                        this.deleteUser(userId, user?.username || 'this user');
+                    });
+                }
+            });
         } catch (err) {
             console.error('Error loading users:', err);
             userList.innerHTML = '<tr><td colspan="5" class="hint">Error loading users</td></tr>';

--- a/public/js/pages/WatchPage.js
+++ b/public/js/pages/WatchPage.js
@@ -538,11 +538,12 @@ class WatchPage {
         }
 
         // Determine if proxy is needed
-        const proxyRequiredDomains = ['pluto.tv'];
-        const needsProxy = settings.forceProxy || proxyRequiredDomains.some(domain => url.includes(domain));
-        const finalUrl = needsProxy ? `/api/proxy/stream?url=${encodeURIComponent(url)}` : url;
+        const isLocalApi = typeof url === 'string' && url.startsWith('/api/');
+        const safeUrl = isLocalApi ? url : Security.safeUrl(url);
+        const finalUrl = isLocalApi ? url : `/api/proxy/stream?url=${encodeURIComponent(safeUrl)}`;
+        const needsProxy = true;
 
-        console.log('[WatchPage] Playing:', { url, needsProxy, looksLikeHls });
+        console.log('[WatchPage] Playing through the local security proxy:', { needsProxy, looksLikeHls });
 
         // Use HLS.js for HLS streams
         if (looksLikeHls && Hls.isSupported()) {
@@ -916,7 +917,7 @@ class WatchPage {
             if (track.kind === 'subtitles' || track.kind === 'captions') {
                 const label = track.label || track.language || `Track ${i + 1}`;
                 const isActive = track.mode === 'showing';
-                html += `<button class="captions-option ${isActive ? 'active' : ''}" data-index="${i}">${label}</button>`;
+                html += `<button class="captions-option ${isActive ? 'active' : ''}" data-index="${i}">${Security.escapeHtml(label)}</button>`;
             }
         }
 
@@ -1046,7 +1047,7 @@ class WatchPage {
             this.posterEl.onerror = null;
             this.posterEl.src = fallback;
         };
-        this.posterEl.src = this.content.poster || fallback;
+        this.posterEl.src = Security.imageUrl(this.content.poster, fallback);
         this.posterEl.alt = this.content.title || '';
         this.contentTitleEl.textContent = this.content.title || '';
         this.yearEl.textContent = this.content.year || '';
@@ -1139,11 +1140,10 @@ class WatchPage {
         if (!this.recommendedGrid) return;
 
         this.recommendedGrid.innerHTML = movies.map(movie => `
-            <div class="watch-recommended-card" data-id="${movie.stream_id}" data-source="${sourceId}">
-                <img src="${movie.stream_icon || movie.cover || '/img/placeholder.png'}" 
-                     alt="${movie.name}" 
-                     onerror="this.onerror=null;this.src='/img/placeholder.png'" loading="lazy">
-                <p>${movie.name}</p>
+            <div class="watch-recommended-card" data-id="${Security.escapeAttribute(movie.stream_id)}" data-source="${Security.escapeAttribute(sourceId)}">
+                <img src="${Security.escapeAttribute(Security.imageUrl(movie.stream_icon || movie.cover))}"
+                     alt="${Security.escapeAttribute(movie.name || '')}" loading="lazy">
+                <p>${Security.escapeHtml(movie.name || 'Unknown')}</p>
             </div>
         `).join('');
 
@@ -1199,7 +1199,7 @@ class WatchPage {
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon">
                             <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/>
                         </svg>
-                        <span class="watch-season-name">Season ${seasonNum}</span>
+                        <span class="watch-season-name">Season ${Security.escapeHtml(seasonNum)}</span>
                         <span class="watch-season-count">${episodes.length} episodes</span>
                     </div>
                     <div class="watch-episode-list">
@@ -1208,13 +1208,13 @@ class WatchPage {
                     parseInt(ep.episode_num) === parseInt(this.currentEpisode);
                 return `
                                 <div class="watch-episode-item ${isActive ? 'active' : ''}" 
-                                     data-episode-id="${ep.id}" 
-                                     data-season="${seasonNum}"
-                                     data-episode="${ep.episode_num}"
-                                     data-container="${ep.container_extension || 'mp4'}">
-                                    <span class="watch-episode-num">E${ep.episode_num}</span>
-                                    <span class="watch-episode-title">${ep.title || `Episode ${ep.episode_num}`}</span>
-                                    <span class="watch-episode-duration">${ep.duration || ''}</span>
+                                     data-episode-id="${Security.escapeAttribute(ep.id)}"
+                                     data-season="${Security.escapeAttribute(seasonNum)}"
+                                     data-episode="${Security.escapeAttribute(ep.episode_num)}"
+                                     data-container="${Security.escapeAttribute(ep.container_extension || 'mp4')}">
+                                    <span class="watch-episode-num">E${Security.escapeHtml(ep.episode_num)}</span>
+                                    <span class="watch-episode-title">${Security.escapeHtml(ep.title || `Episode ${ep.episode_num}`)}</span>
+                                    <span class="watch-episode-duration">${Security.escapeHtml(ep.duration || '')}</span>
                                 </div>
                             `;
             }).join('')}

--- a/public/js/security.js
+++ b/public/js/security.js
@@ -1,0 +1,49 @@
+(function () {
+    const PLACEHOLDER = '/img/placeholder.png';
+
+    function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>'"]/g, character => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            "'": '&#39;',
+            '"': '&quot;'
+        })[character]);
+    }
+
+    function safeUrl(value, fallback = '') {
+        if (typeof value !== 'string' || !value.trim()) return fallback;
+        try {
+            const parsed = new URL(value, window.location.origin);
+            if (!['http:', 'https:'].includes(parsed.protocol)) return fallback;
+            if (parsed.origin === window.location.origin) {
+                return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+            }
+            return parsed.href;
+        } catch {
+            return fallback;
+        }
+    }
+
+    function imageUrl(value, fallback = PLACEHOLDER) {
+        const safe = safeUrl(value, fallback);
+        if (!safe || safe === fallback || safe.startsWith('/')) return safe || fallback;
+        return `/api/proxy/image?url=${encodeURIComponent(safe)}`;
+    }
+
+    document.addEventListener('error', event => {
+        const target = event.target;
+        if (target instanceof HTMLImageElement && !target.dataset.fallbackApplied) {
+            target.dataset.fallbackApplied = 'true';
+            target.src = target.dataset.fallback || PLACEHOLDER;
+        }
+    }, true);
+
+    window.Security = Object.freeze({
+        escapeHtml,
+        escapeAttribute: escapeHtml,
+        safeUrl,
+        imageUrl,
+        PLACEHOLDER
+    });
+})();

--- a/public/login.html
+++ b/public/login.html
@@ -180,7 +180,7 @@
                 Welcome! Please create your admin account to get started.
             </div>
 
-            <form id="login-form">
+            <form id="login-form" method="post" action="/api/auth/login">
                 <div class="form-group">
                     <label for="username">Username</label>
                     <input type="text" id="username" name="username" required autocomplete="username"

--- a/scripts/start-nodecast.ps1
+++ b/scripts/start-nodecast.ps1
@@ -1,0 +1,69 @@
+param(
+    [switch]$NoBrowser
+)
+
+$ErrorActionPreference = 'Stop'
+$projectRoot = Split-Path -Parent $PSScriptRoot
+$dockerDesktop = 'C:\Program Files\Docker\Docker\Docker Desktop.exe'
+$nodeCastUrl = 'http://127.0.0.1:3000'
+
+function Test-DockerEngine {
+    & docker info *> $null
+    return $LASTEXITCODE -eq 0
+}
+
+try {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        throw 'Docker não foi encontrado. Instale o Docker Desktop antes de iniciar o NodeCast.'
+    }
+
+    if (-not (Test-DockerEngine)) {
+        if (-not (Test-Path -LiteralPath $dockerDesktop)) {
+            throw 'Docker Desktop não foi encontrado no local esperado.'
+        }
+
+        Start-Process -FilePath $dockerDesktop -WindowStyle Hidden
+        $dockerDeadline = (Get-Date).AddMinutes(2)
+        do {
+            Start-Sleep -Seconds 2
+            $dockerReady = Test-DockerEngine
+        } until ($dockerReady -or (Get-Date) -gt $dockerDeadline)
+
+        if (-not $dockerReady) {
+            throw 'O Docker Desktop não ficou disponível dentro de dois minutos.'
+        }
+    }
+
+    Push-Location -LiteralPath $projectRoot
+    try {
+        & docker compose up -d
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Não foi possível iniciar o container do NodeCast.'
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $healthDeadline = (Get-Date).AddMinutes(1)
+    do {
+        Start-Sleep -Seconds 1
+        $health = & docker inspect nodecast-tv --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>$null
+    } until ($health -eq 'healthy' -or (Get-Date) -gt $healthDeadline)
+
+    if ($health -ne 'healthy') {
+        throw "O NodeCast iniciou, mas não ficou saudável (estado: $health)."
+    }
+
+    if (-not $NoBrowser) {
+        Start-Process $nodeCastUrl
+    }
+} catch {
+    Add-Type -AssemblyName PresentationFramework
+    [System.Windows.MessageBox]::Show(
+        $_.Exception.Message,
+        'NodeCast TV',
+        [System.Windows.MessageBoxButton]::OK,
+        [System.Windows.MessageBoxImage]::Error
+    ) | Out-Null
+    exit 1
+}

--- a/server/auth.js
+++ b/server/auth.js
@@ -13,7 +13,7 @@ const { Strategy: LocalStrategy } = require('passport-local');
 // JWT Secret - In production, use environment variable
 const { getRuntimeSecret } = require('./services/runtimeSecret');
 const JWT_SECRET = getRuntimeSecret();
-const JWT_EXPIRY = '24h';
+const JWT_EXPIRY = process.env.JWT_EXPIRY?.trim() || '24h';
 
 /**
  * Hash password using bcrypt
@@ -229,7 +229,20 @@ function configureOidcStrategy(findUserByOidcId, findUserByEmail, createUser) {
 /**
  * Middleware: Require authentication using Passport JWT
  */
-const requireAuth = passport.authenticate('jwt', { session: false });
+function requireAuth(req, res, next) {
+    passport.authenticate('jwt', { session: false }, (err, user) => {
+        if (err) return next(err);
+        if (!user) {
+            return res.status(401).json({
+                error: 'Authentication required',
+                code: 'AUTH_REQUIRED'
+            });
+        }
+
+        req.user = user;
+        next();
+    })(req, res, next);
+}
 
 /**
  * Middleware: Require admin role

--- a/server/auth.js
+++ b/server/auth.js
@@ -11,7 +11,8 @@ const { Strategy: LocalStrategy } = require('passport-local');
  */
 
 // JWT Secret - In production, use environment variable
-const JWT_SECRET = process.env.JWT_SECRET || 'nodecast-tv-secret-key-change-in-production';
+const { getRuntimeSecret } = require('./services/runtimeSecret');
+const JWT_SECRET = getRuntimeSecret();
 const JWT_EXPIRY = '24h';
 
 /**

--- a/server/db.js
+++ b/server/db.js
@@ -3,17 +3,23 @@ const path = require('path');
 const { existsSync, mkdirSync } = require('fs');
 
 // Ensure data directory exists (sync is fine for startup)
-const dataDir = path.join(__dirname, '..', 'data');
+const dataDir = process.env.NODECAST_DATA_DIR
+  ? path.resolve(process.env.NODECAST_DATA_DIR)
+  : path.join(__dirname, '..', 'data');
 if (!existsSync(dataDir)) {
   mkdirSync(dataDir, { recursive: true });
 }
 
 const dbPath = path.join(dataDir, 'db.json');
+let dbCache = null;
+let loadPromise = null;
 
 // Initialize database structure
 async function loadDb() {
-  try {
-    // Check if file exists (using fs.access is better for async, but we can catch ENOENT)
+  if (dbCache) return dbCache;
+  if (loadPromise) return loadPromise;
+
+  loadPromise = (async () => {
     try {
       const fileContent = await fs.readFile(dbPath, 'utf-8');
       const data = JSON.parse(fileContent);
@@ -39,17 +45,24 @@ async function loadDb() {
       }
       throw error;
     }
+  })();
+
+  try {
+    dbCache = await loadPromise;
+    return dbCache;
   } catch (err) {
     console.error('Error loading database:', err);
-    // Return safe default on error to prevent crashing, but log it
-    return {
-      sources: [],
-      hiddenItems: [],
-      favorites: [],
-      settings: getDefaultSettings(),
-      users: [],
-      nextId: 1
+    dbCache = {
+        sources: [],
+        hiddenItems: [],
+        favorites: [],
+        settings: getDefaultSettings(),
+        users: [],
+        nextId: 1
     };
+    return dbCache;
+  } finally {
+    loadPromise = null;
   }
 }
 
@@ -106,10 +119,15 @@ let writeQueue = Promise.resolve();
 const tmpPath = dbPath + '.tmp';
 
 async function saveDb(data) {
+  // Keep one shared in-memory document for the process. Previously, concurrent
+  // read-modify-write operations could each load a separate snapshot and the
+  // later write could silently remove a source created by the earlier one.
+  dbCache = data;
+  const jsonString = JSON.stringify(data, null, 2);
+
   // Queue this write operation - each write waits for the previous one
   writeQueue = writeQueue.then(async () => {
     try {
-      const jsonString = JSON.stringify(data, null, 2);
       // Atomic write: write to temp file, then rename
       // Rename is atomic on most filesystems, preventing corruption on crash
       await fs.writeFile(tmpPath, jsonString);

--- a/server/index.js
+++ b/server/index.js
@@ -1,15 +1,19 @@
 const express = require('express');
 require('dotenv').config();
 const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
 const passport = require('passport');
 const syncService = require('./services/syncService');
 const { seedXtreamSourceFromEnv } = require('./services/sourceSeeder');
+const { getRuntimeSecret } = require('./services/runtimeSecret');
 
 // Initialize database
 require('./db');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || '127.0.0.1';
 
 // Trust proxy headers (X-Forwarded-Proto, X-Forwarded-For, etc.)
 // Required for correct protocol detection behind reverse proxies (nginx, Caddy, etc.)
@@ -18,17 +22,63 @@ app.set('trust proxy', true);
 // Middleware
 app.use(express.json({ limit: '50mb' }));
 
+const publicDir = path.join(__dirname, '..', 'public');
+const inlineScriptHashes = ['index.html', 'login.html'].flatMap(file => {
+    const html = fs.readFileSync(path.join(publicDir, file), 'utf8');
+    return [...html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi)]
+        .map(match => match[1])
+        .filter(script => script.trim())
+        .map(script => `'sha256-${crypto.createHash('sha256').update(script).digest('base64')}'`);
+});
+
+app.use((req, res, next) => {
+    res.set({
+        'Content-Security-Policy': [
+            "default-src 'self'",
+            `script-src 'self' ${inlineScriptHashes.join(' ')}`,
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data: blob:",
+            "media-src 'self' blob:",
+            "connect-src 'self' blob:",
+            "worker-src 'self' blob:",
+            "font-src 'self' data:",
+            "object-src 'none'",
+            "base-uri 'self'",
+            "form-action 'self'",
+            "frame-ancestors 'none'"
+        ].join('; '),
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+        'Referrer-Policy': 'no-referrer',
+        'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=()'
+    });
+    next();
+});
+
 // Initialize Passport
 const session = require('express-session');
 app.use(session({
-    secret: process.env.JWT_SECRET || 'keyboard cat',
+    secret: getRuntimeSecret(),
     resave: false,
-    saveUninitialized: true
+    saveUninitialized: false,
+    cookie: {
+        httpOnly: true,
+        sameSite: 'strict',
+        secure: process.env.NODE_ENV === 'production' && process.env.HTTPS === 'true'
+    }
 }));
 app.use(passport.initialize());
 app.use(passport.session());
 
-app.use(express.static(path.join(__dirname, '..', 'public')));
+app.get('/vendor/hls.min.js', (req, res) => {
+    res.type('application/javascript').sendFile(require.resolve('hls.js/dist/hls.min.js'));
+});
+
+app.use(express.static(publicDir, {
+    dotfiles: 'deny',
+    etag: true,
+    maxAge: process.env.NODE_ENV === 'production' ? '1h' : 0
+}));
 
 // FFMPEG Configuration (optional - for transcoding support)
 // Priority: 1. System FFmpeg (better Docker DNS support), 2. ffmpeg-static npm package
@@ -90,7 +140,6 @@ app.locals.ffmpegPath = findFFmpeg();
 app.locals.ffprobePath = findFFprobe();
 
 // Dynamic services loader - collects exports from files in ./services
-const fs = require('fs');
 const services = {};
 try {
     const servicesDir = path.join(__dirname, 'services');
@@ -199,8 +248,8 @@ app.use((err, req, res, next) => {
     res.status(500).json({ error: 'Internal server error' });
 });
 
-app.listen(PORT, async () => {
-    console.log(`NodeCast TV server running on http://localhost:${PORT}`);
+app.listen(PORT, HOST, async () => {
+    console.log(`NodeCast TV server running on http://${HOST}:${PORT}`);
 
     await seedXtreamSourceFromEnv().catch(err => {
         console.error('[Seed] Failed to create the preconfigured Xtream source:', err.message);

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 const path = require('path');
 const passport = require('passport');
 const syncService = require('./services/syncService');
+const { seedXtreamSourceFromEnv } = require('./services/sourceSeeder');
 
 // Initialize database
 require('./db');
@@ -200,6 +201,10 @@ app.use((err, req, res, next) => {
 
 app.listen(PORT, async () => {
     console.log(`NodeCast TV server running on http://localhost:${PORT}`);
+
+    await seedXtreamSourceFromEnv().catch(err => {
+        console.error('[Seed] Failed to create the preconfigured Xtream source:', err.message);
+    });
 
     // Load plugins
     await loadPlugins().catch(err => {

--- a/server/index.js
+++ b/server/index.js
@@ -2,11 +2,11 @@ const express = require('express');
 require('dotenv').config();
 const path = require('path');
 const fs = require('fs');
-const crypto = require('crypto');
 const passport = require('passport');
 const syncService = require('./services/syncService');
 const { seedXtreamSourceFromEnv } = require('./services/sourceSeeder');
 const { getRuntimeSecret } = require('./services/runtimeSecret');
+const { createInlineScriptHash } = require('./services/contentSecurityPolicy');
 
 // Initialize database
 require('./db');
@@ -28,7 +28,7 @@ const inlineScriptHashes = ['index.html', 'login.html'].flatMap(file => {
     return [...html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi)]
         .map(match => match[1])
         .filter(script => script.trim())
-        .map(script => `'sha256-${crypto.createHash('sha256').update(script).digest('base64')}'`);
+        .map(createInlineScriptHash);
 });
 
 app.use((req, res, next) => {

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -1,5 +1,8 @@
 const express = require('express');
 const router = express.Router();
+const { requireAuth } = require('../auth');
+
+router.use(requireAuth);
 const { getDb } = require('../db/sqlite');
 
 // Helper to map API item types to DB types and tables

--- a/server/routes/probe.js
+++ b/server/routes/probe.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const router = express.Router();
+const { resolvePlaybackUrl } = require('../services/playbackUrl');
+const { publicUrlLabel } = require('../services/externalUrl');
 const { spawn } = require('child_process');
 
 /**
@@ -140,9 +142,16 @@ function analyzeProbeResult(probeResult, url) {
 }
 
 router.get('/', async (req, res) => {
-    const { url, ua } = req.query;
+    let { url } = req.query;
+    const { ua } = req.query;
     if (!url) {
         return res.status(400).json({ error: 'URL parameter is required' });
+    }
+
+    try {
+        url = await resolvePlaybackUrl(url);
+    } catch (error) {
+        return res.status(400).json({ error: error.message });
     }
 
     const ffprobePath = req.app.locals.ffprobePath;
@@ -164,11 +173,11 @@ router.get('/', async (req, res) => {
     // Check cache
     const cached = probeCache.get(cacheKey);
     if (cached && (Date.now() - cached.timestamp < CACHE_TTL)) {
-        console.log(`[Probe] Cache hit for: ${url.substring(0, 50)}...`);
+        console.log(`[Probe] Cache hit for: ${publicUrlLabel(url)}`);
         return res.json(cached.result);
     }
 
-    console.log(`[Probe] Probing: ${url.substring(0, 80)}... ${ua ? `(UA: ${ua})` : ''}`);
+    console.log(`[Probe] Probing: ${publicUrlLabel(url)} ${ua ? '(custom UA)' : ''}`);
 
     try {
         const probeResult = await probeStream(url, ffprobePath, ua);

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -11,7 +11,33 @@ const http = require('http');
 const https = require('https');
 const { spawn } = require('child_process');
 const ffmpegPath = require('ffmpeg-static');
-const { Readable } = require('stream');
+const { fetchValidated } = require('../services/safeFetch');
+const { sealUrl, unsealUrl } = require('../services/urlToken');
+const { publicUrlLabel } = require('../services/externalUrl');
+const { requireAuth } = require('../auth');
+
+function streamProxyPath(url, format = '') {
+    if (!url) return null;
+    const formatHint = format ? `&format=${encodeURIComponent(format)}` : '';
+    return `/api/proxy/stream?token=${encodeURIComponent(sealUrl(url))}${formatHint}`;
+}
+
+router.use('/xtream', requireAuth);
+router.use('/m3u', requireAuth);
+router.use('/epg', requireAuth);
+router.use('/cache', requireAuth);
+
+function sanitizeXtreamAuth(data) {
+    if (!data || typeof data !== 'object') return data;
+    const userInfo = data.user_info && typeof data.user_info === 'object'
+        ? { ...data.user_info }
+        : data.user_info;
+    if (userInfo) {
+        delete userInfo.username;
+        delete userInfo.password;
+    }
+    return { ...data, user_info: userInfo };
+}
 
 // Default cache max age in hours
 const DEFAULT_MAX_AGE_HOURS = 24;
@@ -36,7 +62,7 @@ function getCategoriesFromDb(sourceId, type, includeHidden = false) {
 function getStreamsFromDb(sourceId, type, categoryId = null, includeHidden = false) {
     const db = getDb();
     let query = `
-        SELECT item_id, name, stream_icon, added_at, rating, container_extension, year, category_id, data
+        SELECT item_id, name, stream_icon, stream_url, added_at, rating, container_extension, year, category_id, data
         FROM playlist_items 
         WHERE source_id = ? AND type = ?
     `;
@@ -66,6 +92,7 @@ function getStreamsFromDb(sourceId, type, categoryId = null, includeHidden = fal
             series_id: type === 'series' ? item.item_id : undefined,
             name: item.name,
             stream_icon: item.stream_icon,
+            stream_url: item.stream_url,
             cover: item.stream_icon, // series/vod often use cover
             added: item.added_at,
             rating: item.rating,
@@ -89,12 +116,12 @@ router.get('/xtream/:sourceId', async (req, res) => {
         // Proxy auth check to upstream to ensure credentials are still valid
 
         const cached = cache.get('xtream', source.id, 'auth', 300000);
-        if (cached) return res.json(cached);
+        if (cached) return res.json(sanitizeXtreamAuth(cached));
 
         const api = xtreamApi.createFromSource(source);
         const data = await api.authenticate();
         cache.set('xtream', source.id, 'auth', data);
-        res.json(data);
+        res.json(sanitizeXtreamAuth(data));
     } catch (err) {
         res.status(502).json({ error: 'Upstream error', details: err.message });
     }
@@ -258,7 +285,9 @@ router.get('/xtream/:sourceId/stream/:streamId/:type', async (req, res) => {
             return res.status(400).json({ error: 'Invalid stream type' });
         }
 
-        res.json({ url: streamUrl });
+        // Keep provider credentials on the server. The browser receives only an
+        // authenticated opaque token that becomes invalid when NodeCast restarts.
+        res.json({ url: streamProxyPath(streamUrl, container) });
     } catch (err) {
         console.error('Error getting stream URL:', err);
         res.status(500).json({ error: 'Failed to get stream URL' });
@@ -289,13 +318,16 @@ router.get('/m3u/:sourceId', async (req, res) => {
         // }
         // Note: DB `live` items from M3U sync have `category_id` as their group name usually.
 
-        const reformattedChannels = channels.map(c => ({
-            ...c,
-            id: c.stream_id,
-            groupTitle: c.category_id || 'Uncategorized',
-            url: c.stream_url || c.url,
-            tvgLogo: c.stream_icon
-        }));
+        const reformattedChannels = channels.map(c => {
+            const { stream_url: streamUrl, ...safeChannel } = c;
+            return {
+                ...safeChannel,
+                id: c.stream_id,
+                groupTitle: c.category_id || 'Uncategorized',
+                url: streamProxyPath(streamUrl || c.url, c.container_extension || 'm3u8'),
+                tvgLogo: c.stream_icon
+            };
+        });
 
         const reformattedGroups = groups.map(g => ({
             id: g.category_id,
@@ -466,7 +498,7 @@ router.get('/xtream/:sourceId/:action', async (req, res) => {
             cache.set('xtream', sourceId, cacheKey, data);
         }
 
-        res.json(data);
+        res.json(action === 'auth' ? sanitizeXtreamAuth(data) : data);
     } catch (err) {
         console.error('Xtream proxy error:', err);
         res.status(500).json({ error: err.message });
@@ -490,7 +522,7 @@ router.get('/xtream/:sourceId/stream/:streamId/:type?', async (req, res) => {
         const { container = 'm3u8' } = req.query;
 
         const url = api.buildStreamUrl(streamId, type, container);
-        res.json({ url });
+        res.json({ url: streamProxyPath(url, container) });
     } catch (err) {
         console.error('Stream URL error:', err);
         res.status(500).json({ error: err.message });
@@ -606,9 +638,16 @@ router.get('/stream', async (req, res) => {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
-            let { url } = req.query;
+            let { url, token } = req.query;
+            if (token) {
+                try {
+                    url = unsealUrl(token);
+                } catch (error) {
+                    return res.status(400).json({ error: error.message });
+                }
+            }
             if (!url) {
-                return res.status(400).json({ error: 'URL required' });
+                return res.status(400).json({ error: 'Stream token required' });
             }
 
             // Forward some headers to be more "transparent" back to the origin
@@ -631,7 +670,11 @@ router.get('/stream', async (req, res) => {
                 headers['Range'] = rangeHeader;
             }
 
-            const response = await fetch(url, { headers });
+            const response = await fetchValidated(url, {
+                headers,
+                signal: AbortSignal.timeout(15000),
+                preferHttps: true
+            });
 
             // Retry on 5xx errors (transient upstream issues)
             if (response.status >= 500 && attempt < maxRetries) {
@@ -641,7 +684,7 @@ router.get('/stream', async (req, res) => {
             }
 
             if (!response.ok) {
-                console.error(`Upstream error for ${url.substring(0, 80)}...: ${response.status} ${response.statusText}`);
+                console.error(`Upstream error for ${publicUrlLabel(url)}: ${response.status} ${response.statusText}`);
                 if (response.status === 403) {
                     const errorBody = await response.text().catch(() => 'N/A');
                     console.error(`403 Response body: ${errorBody.substring(0, 200)}`);
@@ -702,7 +745,7 @@ router.get('/stream', async (req, res) => {
 
                 const buffer = Buffer.concat(chunks);
                 const finalUrl = response.url || url;
-                console.log(`[Proxy] Processing HLS manifest from: ${finalUrl.substring(0, 80)}...`);
+                console.log(`[Proxy] Processing HLS manifest from: ${publicUrlLabel(finalUrl)}`);
                 res.set('Content-Type', 'application/vnd.apple.mpegurl');
 
                 let manifest = buffer.toString('utf-8');
@@ -719,7 +762,7 @@ router.get('/stream', async (req, res) => {
                             return line.replace(/URI=["']([^"']+)["']/g, (match, p1) => {
                                 try {
                                     const absoluteUrl = new URL(p1, baseUrl).href;
-                                    return `URI="${req.protocol}://${req.get('host')}${req.baseUrl}/stream?url=${encodeURIComponent(absoluteUrl)}"`;
+                                    return `URI="${streamProxyPath(absoluteUrl)}"`;
                                 } catch (e) {
                                     return match;
                                 }
@@ -736,7 +779,7 @@ router.get('/stream', async (req, res) => {
                         } else {
                             absoluteUrl = new URL(trimmed, baseUrl).href;
                         }
-                        return `${req.protocol}://${req.get('host')}${req.baseUrl}/stream?url=${encodeURIComponent(absoluteUrl)}`;
+                        return streamProxyPath(absoluteUrl);
                     } catch (e) { return line; }
                 }).join('\n');
 
@@ -791,7 +834,7 @@ router.get('/image', async (req, res) => {
             return res.status(400).json({ error: 'URL required' });
         }
 
-        const response = await fetch(url, {
+        const response = await fetchValidated(url, {
             headers: {
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
                 'Accept': 'image/*,*/*;q=0.8'
@@ -802,20 +845,32 @@ router.get('/image', async (req, res) => {
             return res.status(response.status).send('Failed to fetch image');
         }
 
-        const contentType = response.headers.get('content-type') || 'image/png';
+        const contentType = (response.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+        const allowedTypes = new Set([
+            'image/png', 'image/jpeg', 'image/gif', 'image/webp',
+            'image/avif', 'image/bmp', 'image/x-icon', 'image/vnd.microsoft.icon'
+        ]);
+        if (!allowedTypes.has(contentType)) {
+            return res.status(415).send('Unsupported image type');
+        }
+
+        const declaredLength = Number(response.headers.get('content-length') || 0);
+        if (declaredLength > 10 * 1024 * 1024) {
+            return res.status(413).send('Image is too large');
+        }
+
         res.set('Content-Type', contentType);
         res.set('Access-Control-Allow-Origin', '*');
         res.set('Cache-Control', 'public, max-age=86400'); // Cache for 24 hours
 
-        // Efficiently pipe the response body
-        if (response.body) {
-            // response.body is an AsyncIterable in standard fetch/undici
-            // Readable.from converts it to a Node.js Readable stream
-            const stream = Readable.from(response.body);
-            stream.pipe(res);
-        } else {
-            res.end();
+        const chunks = [];
+        let total = 0;
+        for await (const chunk of response.body || []) {
+            total += chunk.byteLength;
+            if (total > 10 * 1024 * 1024) return res.status(413).send('Image is too large');
+            chunks.push(Buffer.from(chunk));
         }
+        res.send(Buffer.concat(chunks));
 
     } catch (err) {
         console.error('Image proxy error:', err.message);

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -244,8 +244,9 @@ router.get('/xtream/:sourceId/stream/:streamId/:type', async (req, res) => {
         // Format: http://server:port/movie/username/password/streamId.container (for movie)
         // Format: http://server:port/series/username/password/streamId.container (for series)
 
+        const api = xtreamApi.createFromSource(source);
+        const baseUrl = await api.selectAvailable();
         let streamUrl;
-        const baseUrl = source.url.replace(/\/$/, ''); // Remove trailing slash
 
         if (type === 'live') {
             streamUrl = `${baseUrl}/live/${source.username}/${source.password}/${streamId}.${container}`;
@@ -484,6 +485,7 @@ router.get('/xtream/:sourceId/stream/:streamId/:type?', async (req, res) => {
         }
 
         const api = xtreamApi.createFromSource(source);
+        await api.selectAvailable();
         const { streamId, type = 'live' } = req.params;
         const { container = 'm3u8' } = req.query;
 
@@ -526,6 +528,7 @@ router.get('/epg/:sourceId', async (req, res) => {
         let url = source.url;
         if (source.type === 'xtream') {
             const api = xtreamApi.createFromSource(source);
+            await api.selectAvailable();
             url = api.getXmltvUrl();
         }
 

--- a/server/routes/remux.js
+++ b/server/routes/remux.js
@@ -2,6 +2,8 @@ const express = require('express');
 const router = express.Router();
 const { spawn } = require('child_process');
 const db = require('../db');
+const { resolvePlaybackUrl } = require('../services/playbackUrl');
+const { publicUrlLabel } = require('../services/externalUrl');
 
 /**
  * Remux stream (container conversion only)
@@ -14,9 +16,15 @@ const db = require('../db');
  * Note: This does NOT fix Dolby/AC3 audio issues - use /api/transcode for that.
  */
 router.get('/', async (req, res) => {
-    const { url } = req.query;
+    let { url } = req.query;
     if (!url) {
         return res.status(400).json({ error: 'URL parameter is required' });
+    }
+
+    try {
+        url = await resolvePlaybackUrl(url);
+    } catch (error) {
+        return res.status(400).json({ error: error.message });
     }
 
     const ffmpegPath = req.app.locals.ffmpegPath || 'ffmpeg';
@@ -25,7 +33,7 @@ router.get('/', async (req, res) => {
     const settings = await db.settings.get();
     const userAgent = db.getUserAgent(settings);
 
-    console.log(`[Remux] Starting remux for: ${url}`);
+    console.log(`[Remux] Starting remux for: ${publicUrlLabel(url)}`);
     console.log(`[Remux] Using User-Agent: ${settings.userAgentPreset}`);
 
     // FFmpeg arguments for pure remux (no encoding)
@@ -73,7 +81,6 @@ router.get('/', async (req, res) => {
         '-' // Output to stdout
     ];
 
-    console.log(`[Remux] Full command: ${ffmpegPath} ${args.join(' ')}`);
 
     let ffmpeg;
     try {

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -1,5 +1,8 @@
 const express = require('express');
 const router = express.Router();
+const { requireAuth } = require('../auth');
+
+router.use(requireAuth);
 const { settings, getDefaultSettings } = require('../db');
 const syncService = require('../services/syncService');
 

--- a/server/routes/sources.js
+++ b/server/routes/sources.js
@@ -5,17 +5,29 @@ const { getDb } = require('../db/sqlite');
 const xtreamApi = require('../services/xtreamApi');
 const syncService = require('../services/syncService');
 const m3uParser = require('../services/m3uParser');
+const { requireAuth, requireAdmin } = require('../auth');
+const { validateExternalUrl } = require('../services/externalUrl');
+const { fetchValidated } = require('../services/safeFetch');
+
+router.use(requireAuth);
+
+function sanitizeSource(source) {
+    if (!source) return source;
+    const { password, ...safe } = source;
+    return { ...safe, hasPassword: Boolean(password) };
+}
+
+async function validateSourceUrls(primaryUrl, fallbackUrls = []) {
+    const normalized = xtreamApi.normalizeBaseUrls(primaryUrl, fallbackUrls);
+    await Promise.all(normalized.map(value => validateExternalUrl(value)));
+    return normalized;
+}
 
 // Get all sources
 router.get('/', async (req, res) => {
     try {
         const allSources = await sources.getAll();
-        // Don't expose passwords in list view
-        const sanitized = allSources.map(s => ({
-            ...s,
-            password: s.password ? '••••••••' : null
-        }));
-        res.json(sanitized);
+        res.json(allSources.map(sanitizeSource));
     } catch (err) {
         console.error('Error getting sources:', err);
         res.status(500).json({ error: 'Failed to get sources' });
@@ -39,7 +51,7 @@ router.get('/status', async (req, res) => {
 router.get('/type/:type', async (req, res) => {
     try {
         const typeSources = await sources.getByType(req.params.type);
-        res.json(typeSources);
+        res.json(typeSources.map(sanitizeSource));
     } catch (err) {
         console.error('Error getting sources by type:', err);
         res.status(500).json({ error: 'Failed to get sources' });
@@ -53,7 +65,7 @@ router.get('/:id', async (req, res) => {
         if (!source) {
             return res.status(404).json({ error: 'Source not found' });
         }
-        res.json(source);
+        res.json(sanitizeSource(source));
     } catch (err) {
         console.error('Error getting source:', err);
         res.status(500).json({ error: 'Failed to get source' });
@@ -61,7 +73,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // Create source
-router.post('/', async (req, res) => {
+router.post('/', requireAdmin, async (req, res) => {
     try {
         const { type, name, url, username, password, fallbackUrls } = req.body;
 
@@ -75,24 +87,25 @@ router.post('/', async (req, res) => {
 
         const sourceData = { type, name, url, username, password };
         if (type === 'xtream') {
-            sourceData.url = url.replace(/\/+$/, '');
-            sourceData.fallbackUrls = xtreamApi
-                .normalizeBaseUrls(null, fallbackUrls)
-                .filter(item => item !== sourceData.url);
+            const normalized = await validateSourceUrls(url, fallbackUrls);
+            sourceData.url = normalized[0];
+            sourceData.fallbackUrls = normalized.slice(1);
+        } else {
+            sourceData.url = (await validateExternalUrl(url)).href;
         }
 
         const source = await sources.create(sourceData);
         // Trigger Sync
         syncService.syncSource(source.id).catch(console.error);
-        res.status(201).json(source);
+        res.status(201).json(sanitizeSource(source));
     } catch (err) {
         console.error('Error creating source:', err);
-        res.status(500).json({ error: 'Failed to create source' });
+        res.status(400).json({ error: err.message || 'Failed to create source' });
     }
 });
 
 // Update source
-router.put('/:id', async (req, res) => {
+router.put('/:id', requireAdmin, async (req, res) => {
     try {
         const existing = await sources.getById(req.params.id);
         if (!existing) {
@@ -108,27 +121,29 @@ router.put('/:id', async (req, res) => {
         };
 
         if (existing.type === 'xtream') {
-            updates.url = updates.url.replace(/\/+$/, '');
-            if (fallbackUrls !== undefined) {
-                updates.fallbackUrls = xtreamApi
-                    .normalizeBaseUrls(null, fallbackUrls)
-                    .filter(item => item !== updates.url);
-            }
+            const normalized = await validateSourceUrls(
+                updates.url,
+                fallbackUrls !== undefined ? fallbackUrls : existing.fallbackUrls
+            );
+            updates.url = normalized[0];
+            updates.fallbackUrls = normalized.slice(1);
             xtreamApi.clearPreferred(req.params.id);
+        } else {
+            updates.url = (await validateExternalUrl(updates.url)).href;
         }
 
         const updated = await sources.update(req.params.id, updates);
         // Trigger Sync (if critical fields changed? safely just trigger it)
         syncService.syncSource(parseInt(req.params.id)).catch(console.error);
-        res.json(updated);
+        res.json(sanitizeSource(updated));
     } catch (err) {
         console.error('Error updating source:', err);
-        res.status(500).json({ error: 'Failed to update source' });
+        res.status(400).json({ error: err.message || 'Failed to update source' });
     }
 });
 
 // Delete source
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', requireAdmin, async (req, res) => {
     try {
         const sourceId = parseInt(req.params.id);
         const existing = await sources.getById(sourceId);
@@ -161,7 +176,7 @@ router.delete('/:id', async (req, res) => {
 });
 
 // Toggle source enabled/disabled
-router.post('/:id/toggle', async (req, res) => {
+router.post('/:id/toggle', requireAdmin, async (req, res) => {
     try {
         const updated = await sources.toggleEnabled(req.params.id);
         if (!updated) {
@@ -173,7 +188,7 @@ router.post('/:id/toggle', async (req, res) => {
             syncService.syncSource(parseInt(req.params.id)).catch(console.error);
         }
 
-        res.json(updated);
+        res.json(sanitizeSource(updated));
     } catch (err) {
         console.error('Error toggling source:', err);
         res.status(500).json({ error: 'Failed to toggle source' });
@@ -181,7 +196,7 @@ router.post('/:id/toggle', async (req, res) => {
 });
 
 // Manual Sync
-router.post('/:id/sync', async (req, res) => {
+router.post('/:id/sync', requireAdmin, async (req, res) => {
     try {
         const id = parseInt(req.params.id);
         const source = await sources.getById(id);
@@ -198,7 +213,7 @@ router.post('/:id/sync', async (req, res) => {
 });
 
 // Test source connection
-router.post('/:id/test', async (req, res) => {
+router.post('/:id/test', requireAdmin, async (req, res) => {
     try {
         const source = await sources.getById(req.params.id);
         if (!source) {
@@ -210,12 +225,12 @@ router.post('/:id/test', async (req, res) => {
             const result = await api.authenticate();
             res.json({ success: true, activeUrl: api.baseUrl, data: result });
         } else if (source.type === 'm3u') {
-            const response = await fetch(source.url);
+            const response = await fetchValidated(source.url, { preferHttps: true });
             const text = await response.text();
             const isValid = text.includes('#EXTM3U');
             res.json({ success: isValid, message: isValid ? 'Valid M3U playlist' : 'Invalid M3U format' });
         } else if (source.type === 'epg') {
-            const response = await fetch(source.url);
+            const response = await fetchValidated(source.url, { preferHttps: true });
             const text = await response.text();
             const isValid = text.includes('<tv') || text.includes('<?xml');
             res.json({ success: isValid, message: isValid ? 'Valid EPG XML' : 'Invalid EPG format' });
@@ -230,7 +245,7 @@ router.post('/:id/test', async (req, res) => {
 const M3U_LARGE_THRESHOLD = 50000;
 
 // Estimate by URL (for new sources before creation)
-router.post('/estimate', async (req, res) => {
+router.post('/estimate', requireAdmin, async (req, res) => {
     try {
         const { url, type } = req.body;
 
@@ -287,7 +302,7 @@ router.get('/:id/estimate', async (req, res) => {
 });
 
 // Global Sync - sync all enabled sources
-router.post('/sync-all', async (req, res) => {
+router.post('/sync-all', requireAdmin, async (req, res) => {
     try {
         // Trigger global sync (async - don't wait for completion)
         syncService.syncAll().catch(console.error);

--- a/server/routes/sources.js
+++ b/server/routes/sources.js
@@ -63,7 +63,7 @@ router.get('/:id', async (req, res) => {
 // Create source
 router.post('/', async (req, res) => {
     try {
-        const { type, name, url, username, password } = req.body;
+        const { type, name, url, username, password, fallbackUrls } = req.body;
 
         if (!type || !name || !url) {
             return res.status(400).json({ error: 'Type, name, and URL are required' });
@@ -73,7 +73,15 @@ router.post('/', async (req, res) => {
             return res.status(400).json({ error: 'Invalid source type' });
         }
 
-        const source = await sources.create({ type, name, url, username, password });
+        const sourceData = { type, name, url, username, password };
+        if (type === 'xtream') {
+            sourceData.url = url.replace(/\/+$/, '');
+            sourceData.fallbackUrls = xtreamApi
+                .normalizeBaseUrls(null, fallbackUrls)
+                .filter(item => item !== sourceData.url);
+        }
+
+        const source = await sources.create(sourceData);
         // Trigger Sync
         syncService.syncSource(source.id).catch(console.error);
         res.status(201).json(source);
@@ -91,13 +99,25 @@ router.put('/:id', async (req, res) => {
             return res.status(404).json({ error: 'Source not found' });
         }
 
-        const { name, url, username, password } = req.body;
-        const updated = await sources.update(req.params.id, {
+        const { name, url, username, password, fallbackUrls } = req.body;
+        const updates = {
             name: name || existing.name,
             url: url || existing.url,
             username: username !== undefined ? username : existing.username,
             password: password !== undefined ? password : existing.password
-        });
+        };
+
+        if (existing.type === 'xtream') {
+            updates.url = updates.url.replace(/\/+$/, '');
+            if (fallbackUrls !== undefined) {
+                updates.fallbackUrls = xtreamApi
+                    .normalizeBaseUrls(null, fallbackUrls)
+                    .filter(item => item !== updates.url);
+            }
+            xtreamApi.clearPreferred(req.params.id);
+        }
+
+        const updated = await sources.update(req.params.id, updates);
         // Trigger Sync (if critical fields changed? safely just trigger it)
         syncService.syncSource(parseInt(req.params.id)).catch(console.error);
         res.json(updated);
@@ -186,8 +206,9 @@ router.post('/:id/test', async (req, res) => {
         }
 
         if (source.type === 'xtream') {
-            const result = await xtreamApi.authenticate(source.url, source.username, source.password);
-            res.json({ success: true, data: result });
+            const api = xtreamApi.createFromSource(source);
+            const result = await api.authenticate();
+            res.json({ success: true, activeUrl: api.baseUrl, data: result });
         } else if (source.type === 'm3u') {
             const response = await fetch(source.url);
             const text = await response.text();

--- a/server/routes/subtitle.js
+++ b/server/routes/subtitle.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { spawn } = require('child_process');
+const { resolvePlaybackUrl } = require('../services/playbackUrl');
 
 /**
  * Subtitle extraction endpoint
@@ -8,11 +9,18 @@ const { spawn } = require('child_process');
  * 
  * Extracts a specific subtitle track and converts it to WebVTT on the fly.
  */
-router.get('/', (req, res) => {
-    const { url, index } = req.query;
+router.get('/', async (req, res) => {
+    let { url } = req.query;
+    const { index } = req.query;
 
     if (!url || index === undefined) {
         return res.status(400).json({ error: 'URL and index parameters are required' });
+    }
+
+    try {
+        url = await resolvePlaybackUrl(url);
+    } catch (error) {
+        return res.status(400).json({ error: error.message });
     }
 
     const ffmpegPath = req.app.locals.ffmpegPath || 'ffmpeg';

--- a/server/routes/transcode.js
+++ b/server/routes/transcode.js
@@ -5,6 +5,8 @@ const path = require('path');
 const fs = require('fs').promises;
 const db = require('../db');
 const transcodeSession = require('../services/transcodeSession');
+const { resolvePlaybackUrl } = require('../services/playbackUrl');
+const { publicUrlLabel } = require('../services/externalUrl');
 
 /**
  * Transcode Routes
@@ -29,10 +31,17 @@ transcodeSession.startCleanupInterval();
  * Body: { url: string, seekOffset?: number }
  */
 router.post('/session', async (req, res) => {
-    const { url, seekOffset, videoMode, videoCodec, audioCodec, audioChannels } = req.body;
+    let { url } = req.body;
+    const { seekOffset, videoMode, videoCodec, audioCodec, audioChannels } = req.body;
 
     if (!url) {
         return res.status(400).json({ error: 'URL is required' });
+    }
+
+    try {
+        url = await resolvePlaybackUrl(url);
+    } catch (error) {
+        return res.status(400).json({ error: error.message });
     }
 
     const ffmpegPath = req.app.locals.ffmpegPath || 'ffmpeg';
@@ -160,9 +169,15 @@ router.get('/sessions', (req, res) => {
  * This fixes playback issues with Dolby/AC3/EAC3 audio that browsers can't decode.
  */
 router.get('/', async (req, res) => {
-    const { url } = req.query;
+    let { url } = req.query;
     if (!url) {
         return res.status(400).json({ error: 'URL parameter is required' });
+    }
+
+    try {
+        url = await resolvePlaybackUrl(url);
+    } catch (error) {
+        return res.status(400).json({ error: error.message });
     }
 
     const ffmpegPath = req.app.locals.ffmpegPath || 'ffmpeg';
@@ -171,7 +186,7 @@ router.get('/', async (req, res) => {
     const settings = await db.settings.get();
     const userAgent = db.getUserAgent(settings);
 
-    console.log(`[Transcode] Starting transcoding for: ${url}`);
+    console.log(`[Transcode] Starting transcoding for: ${publicUrlLabel(url)}`);
     console.log(`[Transcode] Using User-Agent: ${settings.userAgentPreset}`);
     console.log(`[Transcode] Using binary: ${ffmpegPath}`);
 
@@ -220,7 +235,6 @@ router.get('/', async (req, res) => {
         '-' // Output to stdout
     ];
 
-    console.log(`[Transcode] Full command: ${ffmpegPath} ${args.join(' ')}`);
 
     let ffmpeg;
     try {

--- a/server/services/contentSecurityPolicy.js
+++ b/server/services/contentSecurityPolicy.js
@@ -1,0 +1,12 @@
+const crypto = require('crypto');
+
+function normalizeInlineScript(script) {
+    return script.replace(/\r\n?/g, '\n');
+}
+
+function createInlineScriptHash(script) {
+    const normalized = normalizeInlineScript(script);
+    return `'sha256-${crypto.createHash('sha256').update(normalized).digest('base64')}'`;
+}
+
+module.exports = { normalizeInlineScript, createInlineScriptHash };

--- a/server/services/epgParser.js
+++ b/server/services/epgParser.js
@@ -4,6 +4,7 @@
  */
 
 const sax = require('sax');
+const { fetchValidated } = require('./safeFetch');
 const zlib = require('zlib');
 const { Readable } = require('stream');
 
@@ -183,7 +184,7 @@ function getCurrentAndUpcoming(programmes, channelId, count = 5) {
  * Fetch and parse XMLTV from URL
  */
 async function fetchAndParse(url) {
-    const response = await fetch(url);
+    const response = await fetchValidated(url, { preferHttps: true });
     if (!response.ok) {
         throw new Error(`Failed to fetch EPG: ${response.status} ${response.statusText}`);
     }
@@ -233,7 +234,7 @@ async function fetchAndParse(url) {
  * @yields {{ channels: Array|null, programmes: Array, isLast: boolean }}
  */
 async function* fetchAndParseStreaming(url, batchSize = 1000) {
-    const response = await fetch(url);
+    const response = await fetchValidated(url, { preferHttps: true });
     if (!response.ok) {
         throw new Error(`Failed to fetch EPG: ${response.status} ${response.statusText}`);
     }

--- a/server/services/externalUrl.js
+++ b/server/services/externalUrl.js
@@ -1,0 +1,95 @@
+const dns = require('dns').promises;
+const net = require('net');
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+function isPrivateIpv4(address) {
+    const parts = address.split('.').map(Number);
+    if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
+        return true;
+    }
+
+    const [a, b, c] = parts;
+    return a === 0 || a === 10 || a === 127 ||
+        (a === 100 && b >= 64 && b <= 127) ||
+        (a === 169 && b === 254) ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 0) ||
+        (a === 192 && b === 168) ||
+        (a === 192 && b === 88 && c === 99) ||
+        (a === 198 && (b === 18 || b === 19)) ||
+        (a === 198 && b === 51 && c === 100) ||
+        (a === 203 && b === 0 && c === 113) ||
+        a >= 224;
+}
+
+function isPrivateIp(address) {
+    const normalized = String(address).toLowerCase().split('%')[0];
+    if (net.isIPv4(normalized)) return isPrivateIpv4(normalized);
+    if (!net.isIPv6(normalized)) return true;
+
+    if (normalized.startsWith('::ffff:')) {
+        const mapped = normalized.slice(7);
+        if (net.isIPv4(mapped)) return isPrivateIpv4(mapped);
+        const halves = mapped.split(':');
+        if (halves.length === 2) {
+            const high = Number.parseInt(halves[0], 16);
+            const low = Number.parseInt(halves[1], 16);
+            if (Number.isInteger(high) && Number.isInteger(low)) {
+                return isPrivateIpv4(`${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`);
+            }
+        }
+    }
+
+    const firstHextet = Number.parseInt(normalized.split(':')[0] || '0', 16);
+    return normalized === '::' || normalized === '::1' ||
+        normalized.startsWith('fc') || normalized.startsWith('fd') ||
+        /^fe[89ab]/.test(normalized) || normalized.startsWith('ff') ||
+        normalized.startsWith('2001:db8:') || firstHextet < 0x2000 || firstHextet > 0x3fff;
+}
+
+async function validateExternalUrl(value, options = {}) {
+    let url;
+    try {
+        url = new URL(value);
+    } catch {
+        throw new Error('Invalid upstream URL');
+    }
+
+    if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+        throw new Error('Only HTTP and HTTPS upstream URLs are allowed');
+    }
+
+    if (url.username || url.password) {
+        throw new Error('Credentials in the URL authority are not allowed');
+    }
+
+    const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '');
+    if (!hostname || hostname === 'localhost' || hostname.endsWith('.localhost') || hostname.endsWith('.local')) {
+        throw new Error('Local upstream addresses are not allowed');
+    }
+
+    const allowPrivate = options.allowPrivate ?? process.env.ALLOW_PRIVATE_UPSTREAMS === 'true';
+    if (!allowPrivate) {
+        const addresses = net.isIP(hostname)
+            ? [{ address: hostname }]
+            : await dns.lookup(hostname, { all: true, verbatim: true });
+
+        if (!addresses.length || addresses.some(item => isPrivateIp(item.address))) {
+            throw new Error('Private or reserved upstream addresses are not allowed');
+        }
+    }
+
+    return url;
+}
+
+function publicUrlLabel(value) {
+    try {
+        const url = new URL(value);
+        return `${url.protocol}//${url.host}`;
+    } catch {
+        return '[invalid upstream URL]';
+    }
+}
+
+module.exports = { validateExternalUrl, isPrivateIp, publicUrlLabel };

--- a/server/services/m3uParser.js
+++ b/server/services/m3uParser.js
@@ -155,7 +155,7 @@ async function parse(input) {
  * @returns {Promise<{ channels: Array, groups: Array }>}
  */
 async function fetchAndParse(url) {
-    const response = await fetch(url);
+    const response = await fetchValidated(url, { preferHttps: true });
     if (!response.ok) {
         throw new Error(`Failed to fetch M3U: ${response.status} ${response.statusText}`);
     }
@@ -254,7 +254,7 @@ async function* parseStreaming(input, batchSize = 500) {
  * @yields {{ channels: Array, groups: Set, isLast: boolean }}
  */
 async function* fetchAndParseStreaming(url, batchSize = 500) {
-    const response = await fetch(url);
+    const response = await fetchValidated(url, { preferHttps: true });
     if (!response.ok) {
         throw new Error(`Failed to fetch M3U: ${response.status} ${response.statusText}`);
     }
@@ -278,7 +278,8 @@ async function* fetchAndParseStreaming(url, batchSize = 500) {
  * @returns {Promise<number>} Number of entries
  */
 async function countEntries(url) {
-    const response = await fetch(url, {
+    const response = await fetchValidated(url, {
+        preferHttps: true,
         headers: {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
         }
@@ -314,3 +315,4 @@ async function countEntries(url) {
 
 module.exports = { parse, parseExtinf, fetchAndParse, parseStreaming, fetchAndParseStreaming, countEntries };
 
+const { fetchValidated } = require('./safeFetch');

--- a/server/services/playbackUrl.js
+++ b/server/services/playbackUrl.js
@@ -1,0 +1,18 @@
+const { unsealUrl } = require('./urlToken');
+const { validateExternalUrl } = require('./externalUrl');
+
+async function resolvePlaybackUrl(value) {
+    if (typeof value !== 'string' || !value.trim()) throw new Error('Playback URL is required');
+
+    let upstream = value;
+    if (value.startsWith('/api/proxy/stream')) {
+        const local = new URL(value, 'http://127.0.0.1');
+        const token = local.searchParams.get('token');
+        if (!token) throw new Error('A protected stream token is required');
+        upstream = unsealUrl(token);
+    }
+
+    return (await validateExternalUrl(upstream)).href;
+}
+
+module.exports = { resolvePlaybackUrl };

--- a/server/services/runtimeSecret.js
+++ b/server/services/runtimeSecret.js
@@ -1,0 +1,25 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const secretPath = path.join(__dirname, '..', '..', 'data', '.jwt-secret');
+
+function getRuntimeSecret() {
+    if (process.env.JWT_SECRET && process.env.JWT_SECRET.length >= 32) {
+        return process.env.JWT_SECRET;
+    }
+
+    try {
+        const existing = fs.readFileSync(secretPath, 'utf8').trim();
+        if (existing.length >= 32) return existing;
+    } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+    }
+
+    fs.mkdirSync(path.dirname(secretPath), { recursive: true });
+    const generated = crypto.randomBytes(48).toString('base64url');
+    fs.writeFileSync(secretPath, generated, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    return generated;
+}
+
+module.exports = { getRuntimeSecret };

--- a/server/services/safeFetch.js
+++ b/server/services/safeFetch.js
@@ -1,0 +1,56 @@
+const { validateExternalUrl } = require('./externalUrl');
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+async function fetchValidated(value, options = {}) {
+    const {
+        maxRedirects = 5,
+        preferHttps = true,
+        allowPrivate,
+        ...fetchOptions
+    } = options;
+
+    let current = await validateExternalUrl(value, { allowPrivate });
+    let downgradeFallback = null;
+
+    for (let hop = 0; hop <= maxRedirects; hop++) {
+        let response;
+        try {
+            response = await fetch(current, { ...fetchOptions, redirect: 'manual' });
+        } catch (error) {
+            if (downgradeFallback) {
+                current = downgradeFallback;
+                downgradeFallback = null;
+                continue;
+            }
+            throw error;
+        }
+        downgradeFallback = null;
+
+        const location = response.headers.get('location');
+        if (!REDIRECT_STATUSES.has(response.status) || !location) return response;
+        if (hop === maxRedirects) throw new Error('Too many upstream redirects');
+        await response.body?.cancel().catch(() => {});
+
+        let next = await validateExternalUrl(new URL(location, current).href, { allowPrivate });
+        if (preferHttps && current.protocol === 'https:' && next.protocol === 'http:') {
+            downgradeFallback = next;
+            const upgraded = new URL(next);
+            upgraded.protocol = 'https:';
+            try {
+                next = await validateExternalUrl(upgraded.href, { allowPrivate });
+            } catch {
+                next = downgradeFallback;
+                downgradeFallback = null;
+            }
+        } else {
+            downgradeFallback = null;
+        }
+
+        current = next;
+    }
+
+    throw new Error('Unable to fetch upstream URL');
+}
+
+module.exports = { fetchValidated };

--- a/server/services/sourceSeeder.js
+++ b/server/services/sourceSeeder.js
@@ -1,0 +1,42 @@
+const { sources } = require('../db');
+const { normalizeBaseUrls } = require('./xtreamApi');
+
+function getXtreamSeedConfig(env = process.env) {
+    const url = env.SEED_XTREAM_URL?.trim();
+    const username = env.SEED_XTREAM_USERNAME?.trim();
+    const password = env.SEED_XTREAM_PASSWORD?.trim();
+
+    if (!url || !username || !password) {
+        return null;
+    }
+
+    const fallbackUrls = normalizeBaseUrls(null, env.SEED_XTREAM_FALLBACK_URLS)
+        .filter(item => item !== url.replace(/\/+$/, ''));
+
+    return {
+        type: 'xtream',
+        name: env.SEED_XTREAM_NAME?.trim() || 'Preconfigured IPTV',
+        url: url.replace(/\/+$/, ''),
+        username,
+        password,
+        fallbackUrls
+    };
+}
+
+async function seedXtreamSourceFromEnv(env = process.env, sourceStore = sources) {
+    const config = getXtreamSeedConfig(env);
+    if (!config) {
+        return { created: false, reason: 'not-configured' };
+    }
+
+    const allSources = await sourceStore.getAll();
+    if (allSources.some(source => source.type === 'xtream')) {
+        return { created: false, reason: 'already-exists' };
+    }
+
+    const source = await sourceStore.create(config);
+    console.log(`[Seed] Created preconfigured Xtream source "${source.name}"`);
+    return { created: true, sourceId: source.id };
+}
+
+module.exports = { getXtreamSeedConfig, seedXtreamSourceFromEnv };

--- a/server/services/syncService.js
+++ b/server/services/syncService.js
@@ -3,6 +3,7 @@ const { sources, settings } = require('../db'); // For source config and setting
 const xtreamApi = require('./xtreamApi');
 const m3uParser = require('./m3uParser');
 const epgParser = require('./epgParser');
+const { publicUrlLabel } = require('./externalUrl');
 
 // Sync tracking
 const activeSyncs = new Set(); // sourceId
@@ -389,7 +390,7 @@ class SyncService {
      * Processes EPG files in batches to avoid OOM on large EPG data
      */
     async syncEpgFromUrl(sourceId, url) {
-        console.log(`[Sync] Fetching EPG from: ${url.substring(0, 60)}...`);
+        console.log(`[Sync] Fetching EPG from: ${publicUrlLabel(url)}`);
 
         // Temporary memory logging for verification
         const logMemory = () => {

--- a/server/services/transcodeSession.js
+++ b/server/services/transcodeSession.js
@@ -18,6 +18,7 @@ const fs = require('fs').promises;
 const crypto = require('crypto');
 const EventEmitter = require('events');
 const hwDetect = require('./hwDetect');
+const { publicUrlLabel } = require('./externalUrl');
 
 // Session storage
 const sessions = new Map();
@@ -89,7 +90,7 @@ class TranscodeSession extends EventEmitter {
         }
 
         this.status = 'starting';
-        console.log(`[TranscodeSession ${this.id}] Starting session for: ${this.url}`);
+        console.log(`[TranscodeSession ${this.id}] Starting session for: ${publicUrlLabel(this.url)}`);
 
         // Create session directory
         try {
@@ -103,7 +104,6 @@ class TranscodeSession extends EventEmitter {
         // Build FFmpeg arguments for HLS output
         const args = this.buildFFmpegArgs();
 
-        console.log(`[TranscodeSession ${this.id}] Command: ${this.options.ffmpegPath} ${args.join(' ')}`);
 
         try {
             this.process = spawn(this.options.ffmpegPath, args, {

--- a/server/services/urlToken.js
+++ b/server/services/urlToken.js
@@ -1,0 +1,36 @@
+const crypto = require('crypto');
+
+// Tokens are intentionally process-local. Restarting NodeCast invalidates old playback URLs.
+const key = crypto.randomBytes(32);
+
+function sealUrl(value) {
+    const plaintext = Buffer.from(String(value), 'utf8');
+    if (plaintext.length > 16 * 1024) throw new Error('Upstream URL is too long');
+
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return Buffer.concat([iv, tag, encrypted]).toString('base64url');
+}
+
+function unsealUrl(token) {
+    if (typeof token !== 'string' || token.length > 24 * 1024) {
+        throw new Error('Invalid stream token');
+    }
+
+    try {
+        const payload = Buffer.from(token, 'base64url');
+        if (payload.length < 29) throw new Error('Token is too short');
+        const iv = payload.subarray(0, 12);
+        const tag = payload.subarray(12, 28);
+        const encrypted = payload.subarray(28);
+        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+        decipher.setAuthTag(tag);
+        return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+    } catch {
+        throw new Error('Invalid or expired stream token');
+    }
+}
+
+module.exports = { sealUrl, unsealUrl };

--- a/server/services/xtreamApi.js
+++ b/server/services/xtreamApi.js
@@ -5,6 +5,7 @@
 
 const DEFAULT_TIMEOUT_MS = 8000;
 const preferredUrls = new Map();
+const { fetchValidated } = require('./safeFetch');
 
 function normalizeBaseUrls(primaryUrl, fallbackUrls = []) {
     const values = [primaryUrl];
@@ -42,6 +43,7 @@ class XtreamApi {
         this.password = password;
         this.timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
         this.onSuccess = options.onSuccess;
+        this.allowPrivate = options.allowPrivate;
     }
 
     /**
@@ -72,8 +74,10 @@ class XtreamApi {
             const url = this.buildApiUrl(action, params, baseUrl);
 
             try {
-                const response = await fetch(url, {
-                    signal: AbortSignal.timeout(this.timeoutMs)
+                const response = await fetchValidated(url, {
+                    signal: AbortSignal.timeout(this.timeoutMs),
+                    preferHttps: true,
+                    allowPrivate: this.allowPrivate
                 });
                 if (!response.ok) {
                     throw new Error(`${response.status} ${response.statusText}`);

--- a/server/services/xtreamApi.js
+++ b/server/services/xtreamApi.js
@@ -3,19 +3,52 @@
  * Handles authentication and API calls to Xtream servers
  */
 
+const DEFAULT_TIMEOUT_MS = 8000;
+const preferredUrls = new Map();
+
+function normalizeBaseUrls(primaryUrl, fallbackUrls = []) {
+    const values = [primaryUrl];
+
+    if (Array.isArray(fallbackUrls)) {
+        values.push(...fallbackUrls);
+    } else if (typeof fallbackUrls === 'string') {
+        values.push(...fallbackUrls.split(/[\r\n,]+/));
+    }
+
+    return [...new Set(values
+        .filter(value => typeof value === 'string' && value.trim())
+        .map(value => value.trim().replace(/\/+$/, '')))];
+}
+
 class XtreamApi {
-    constructor(baseUrl, username, password) {
-        // Clean up base URL
-        this.baseUrl = baseUrl.replace(/\/+$/, '');
+    constructor(baseUrls, username, password, options = {}) {
+        const urls = Array.isArray(baseUrls)
+            ? normalizeBaseUrls(baseUrls[0], baseUrls.slice(1))
+            : normalizeBaseUrls(baseUrls);
+
+        if (urls.length === 0) {
+            throw new Error('At least one Xtream server URL is required');
+        }
+
+        const preferredUrl = options.preferredUrl?.replace(/\/+$/, '');
+        if (preferredUrl && urls.includes(preferredUrl)) {
+            urls.splice(urls.indexOf(preferredUrl), 1);
+            urls.unshift(preferredUrl);
+        }
+
+        this.baseUrls = urls;
+        this.baseUrl = urls[0];
         this.username = username;
         this.password = password;
+        this.timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+        this.onSuccess = options.onSuccess;
     }
 
     /**
      * Build API URL with authentication
      */
-    buildApiUrl(action, params = {}) {
-        const url = new URL(`${this.baseUrl}/player_api.php`);
+    buildApiUrl(action, params = {}, baseUrl = this.baseUrl) {
+        const url = new URL(`${baseUrl}/player_api.php`);
         url.searchParams.set('username', this.username);
         url.searchParams.set('password', this.password);
         if (action) {
@@ -32,24 +65,49 @@ class XtreamApi {
     /**
      * Make API request
      */
-    async request(action, params = {}) {
-        const url = this.buildApiUrl(action, params);
-        const response = await fetch(url);
-        if (!response.ok) {
-            throw new Error(`Xtream API error: ${response.status} ${response.statusText}`);
+    async request(action, params = {}, validate = null) {
+        const errors = [];
+
+        for (const baseUrl of this.baseUrls) {
+            const url = this.buildApiUrl(action, params, baseUrl);
+
+            try {
+                const response = await fetch(url, {
+                    signal: AbortSignal.timeout(this.timeoutMs)
+                });
+                if (!response.ok) {
+                    throw new Error(`${response.status} ${response.statusText}`);
+                }
+
+                const data = await response.json();
+                if (validate && !validate(data)) {
+                    throw new Error('Invalid credentials or server response');
+                }
+
+                this.baseUrl = baseUrl;
+                this.onSuccess?.(baseUrl);
+                return data;
+            } catch (error) {
+                errors.push(`${baseUrl}: ${error.message}`);
+            }
         }
-        return response.json();
+
+        throw new Error(`All Xtream DNS servers failed (${errors.join(' | ')})`);
     }
 
     /**
      * Authenticate and get server/user info
      */
     async authenticate() {
-        const data = await this.request(null);
-        if (!data.user_info) {
-            throw new Error('Invalid credentials or server response');
-        }
-        return data;
+        return this.request(null, {}, data => Boolean(data?.user_info));
+    }
+
+    /**
+     * Select the first responsive server before returning a direct stream URL.
+     */
+    async selectAvailable() {
+        await this.authenticate();
+        return this.baseUrl;
     }
 
     /**
@@ -147,15 +205,31 @@ class XtreamApi {
  * Factory function to create API instance from source
  */
 function createFromSource(source) {
-    return new XtreamApi(source.url, source.username, source.password);
+    const baseUrls = normalizeBaseUrls(source.url, source.fallbackUrls);
+    const preferredUrl = preferredUrls.get(String(source.id));
+
+    return new XtreamApi(baseUrls, source.username, source.password, {
+        preferredUrl,
+        onSuccess: (url) => preferredUrls.set(String(source.id), url)
+    });
 }
 
 /**
  * Static authenticate for testing
  */
-async function authenticate(url, username, password) {
-    const api = new XtreamApi(url, username, password);
+async function authenticate(url, username, password, fallbackUrls = []) {
+    const api = new XtreamApi(normalizeBaseUrls(url, fallbackUrls), username, password);
     return api.authenticate();
 }
 
-module.exports = { XtreamApi, createFromSource, authenticate };
+function clearPreferred(sourceId) {
+    preferredUrls.delete(String(sourceId));
+}
+
+module.exports = {
+    XtreamApi,
+    createFromSource,
+    authenticate,
+    normalizeBaseUrls,
+    clearPreferred
+};

--- a/test/multiview.test.js
+++ b/test/multiview.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function loadMultiViewPage(documentOverrides = {}) {
+    const grid = {
+        innerHTML: '',
+        addEventListener() {},
+        querySelector() { return null; },
+        classList: { add() {}, remove() {} }
+    };
+    const document = {
+        fullscreenElement: null,
+        webkitFullscreenElement: null,
+        getElementById(id) { return id === 'multiview-grid' ? grid : null; },
+        querySelector() { return null; },
+        querySelectorAll() { return []; },
+        addEventListener() {},
+        ...documentOverrides
+    };
+    const context = {
+        console,
+        document,
+        localStorage: { getItem() { return null; }, setItem() {} },
+        window: {}
+    };
+    vm.runInNewContext(fs.readFileSync('public/js/pages/MultiViewPage.js', 'utf8'), context);
+    return { MultiViewPage: context.window.MultiViewPage, document, grid };
+}
+
+test('multi-view renders and activates the exit-fullscreen control', () => {
+    let exitCalls = 0;
+    const { MultiViewPage, document, grid } = loadMultiViewPage({
+        fullscreenElement: {},
+        exitFullscreen() { exitCalls += 1; }
+    });
+    const page = new MultiViewPage({});
+
+    assert.match(grid.innerHTML, /data-action="exit-fullscreen"/);
+    assert.match(grid.innerHTML, /Sair da tela cheia/);
+    page.exitFullscreen();
+    assert.equal(exitCalls, 1);
+    assert.ok(document.fullscreenElement);
+});

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -3,6 +3,8 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const vm = require('node:vm');
 const { spawnSync } = require('node:child_process');
+const os = require('node:os');
+const path = require('node:path');
 
 const { isPrivateIp, validateExternalUrl } = require('../server/services/externalUrl');
 const { sealUrl, unsealUrl } = require('../server/services/urlToken');
@@ -43,6 +45,28 @@ test('provider 401 errors do not clear the local NodeCast session', async () => 
     await assert.rejects(context.window.API.request('GET', '/proxy/provider'), /Provider rejected/);
     assert.equal(tokenRemoved, false);
     assert.equal(context.window.location.href, '/');
+});
+
+test('concurrent database updates retain sources and users', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodecast-db-test-'));
+    try {
+        const result = spawnSync(process.execPath, ['-e', `
+            process.env.NODECAST_DATA_DIR = process.argv[1];
+            const db = require('./server/db');
+            Promise.all([
+                db.sources.create({ type: 'xtream', name: 'Test source', url: 'https://example.test' }),
+                db.users.create({ username: 'test-user', role: 'admin' })
+            ]).then(async () => {
+                const data = await db.loadDb();
+                process.stdout.write(JSON.stringify({ sources: data.sources.length, users: data.users.length }));
+            }).catch(error => { console.error(error); process.exit(1); });
+        `, tempDir], { cwd: process.cwd(), encoding: 'utf8' });
+
+        assert.equal(result.status, 0, result.stderr);
+        assert.deepEqual(JSON.parse(result.stdout), { sources: 1, users: 1 });
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
 });
 
 test('CSP inline-script hashes are stable across Windows and browser newlines', () => {

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -6,6 +6,14 @@ const vm = require('node:vm');
 const { isPrivateIp, validateExternalUrl } = require('../server/services/externalUrl');
 const { sealUrl, unsealUrl } = require('../server/services/urlToken');
 const { fetchValidated } = require('../server/services/safeFetch');
+const { createInlineScriptHash } = require('../server/services/contentSecurityPolicy');
+
+test('CSP inline-script hashes are stable across Windows and browser newlines', () => {
+    assert.equal(
+        createInlineScriptHash('const ready = true;\r\nconsole.log(ready);\r\n'),
+        createInlineScriptHash('const ready = true;\nconsole.log(ready);\n')
+    );
+});
 
 test('browser security helpers escape markup and reject script URLs', () => {
     const context = {

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -2,11 +2,48 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const vm = require('node:vm');
+const { spawnSync } = require('node:child_process');
 
 const { isPrivateIp, validateExternalUrl } = require('../server/services/externalUrl');
 const { sealUrl, unsealUrl } = require('../server/services/urlToken');
 const { fetchValidated } = require('../server/services/safeFetch');
 const { createInlineScriptHash } = require('../server/services/contentSecurityPolicy');
+
+test('configured JWT lifetime is applied to newly issued tokens', () => {
+    const result = spawnSync(process.execPath, ['-e', `
+        process.env.JWT_SECRET = 'test-only-secret-that-is-at-least-32-characters';
+        process.env.JWT_EXPIRY = '30d';
+        const jwt = require('jsonwebtoken');
+        const auth = require('./server/auth');
+        const payload = jwt.decode(auth.generateToken({ id: 1, username: 'test', role: 'admin' }));
+        process.stdout.write(String(payload.exp - payload.iat));
+    `], { cwd: process.cwd(), encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(Number(result.stdout), 30 * 24 * 60 * 60);
+});
+
+test('provider 401 errors do not clear the local NodeCast session', async () => {
+    let tokenRemoved = false;
+    const context = {
+        window: { location: { href: '/' } },
+        localStorage: {
+            getItem: () => 'local-session-token',
+            removeItem: () => { tokenRemoved = true; }
+        },
+        fetch: async () => ({
+            ok: false,
+            status: 401,
+            headers: { get: () => 'application/json' },
+            json: async () => ({ error: 'Provider rejected the stream' })
+        })
+    };
+    vm.runInNewContext(fs.readFileSync('public/js/api.js', 'utf8'), context);
+
+    await assert.rejects(context.window.API.request('GET', '/proxy/provider'), /Provider rejected/);
+    assert.equal(tokenRemoved, false);
+    assert.equal(context.window.location.href, '/');
+});
 
 test('CSP inline-script hashes are stable across Windows and browser newlines', () => {
     assert.equal(

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const { isPrivateIp, validateExternalUrl } = require('../server/services/externalUrl');
+const { sealUrl, unsealUrl } = require('../server/services/urlToken');
+const { fetchValidated } = require('../server/services/safeFetch');
+
+test('browser security helpers escape markup and reject script URLs', () => {
+    const context = {
+        URL,
+        window: { location: { origin: 'http://127.0.0.1:3000' } },
+        document: { addEventListener: () => {} },
+        HTMLImageElement: class {}
+    };
+    vm.runInNewContext(fs.readFileSync('public/js/security.js', 'utf8'), context);
+
+    assert.equal(
+        context.window.Security.escapeHtml('<img src=x onerror="alert(1)">'),
+        '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;'
+    );
+    assert.equal(context.window.Security.safeUrl('javascript:alert(1)', '/safe'), '/safe');
+    assert.match(
+        context.window.Security.imageUrl('https://images.example/poster.jpg'),
+        /^\/api\/proxy\/image\?url=/
+    );
+});
+
+test('private and loopback addresses are rejected', async () => {
+    assert.equal(isPrivateIp('127.0.0.1'), true);
+    assert.equal(isPrivateIp('192.168.1.2'), true);
+    assert.equal(isPrivateIp('10.0.0.1'), true);
+    assert.equal(isPrivateIp('::1'), true);
+    assert.equal(isPrivateIp('8.8.8.8'), false);
+
+    await assert.rejects(validateExternalUrl('http://127.0.0.1/admin'), /Private|reserved/);
+    await assert.rejects(validateExternalUrl('file:///etc/passwd'), /HTTP and HTTPS/);
+});
+
+test('stream URL tokens conceal credentials and reject tampering', () => {
+    const sensitiveUrl = 'https://provider.example/live/user/secret/123.m3u8';
+    const token = sealUrl(sensitiveUrl);
+
+    assert.equal(token.includes('user'), false);
+    assert.equal(token.includes('secret'), false);
+    assert.equal(unsealUrl(token), sensitiveUrl);
+    const middle = Math.floor(token.length / 2);
+    const tampered = `${token.slice(0, middle)}${token[middle] === 'a' ? 'b' : 'a'}${token.slice(middle + 1)}`;
+    assert.throws(() => unsealUrl(tampered), /Invalid|expired/);
+});
+
+test('HTTPS redirects are upgraded when the media host supports HTTPS', async t => {
+    const originalFetch = global.fetch;
+    t.after(() => { global.fetch = originalFetch; });
+
+    const requested = [];
+    global.fetch = async value => {
+        const url = String(value);
+        requested.push(url);
+        if (url === 'https://provider.test/start') {
+            return {
+                status: 302,
+                headers: { get: name => name === 'location' ? 'http://cdn.test/media.m3u8' : null }
+            };
+        }
+        return {
+            status: 200,
+            ok: true,
+            headers: { get: () => null }
+        };
+    };
+
+    const response = await fetchValidated('https://provider.test/start', { allowPrivate: true });
+    assert.equal(response.status, 200);
+    assert.deepEqual(requested, [
+        'https://provider.test/start',
+        'https://cdn.test/media.m3u8'
+    ]);
+});

--- a/test/xtreamApi.test.js
+++ b/test/xtreamApi.test.js
@@ -17,12 +17,15 @@ test('Xtream API falls back and remembers the responsive URL', async (t) => {
 
     const requestedHosts = [];
     global.fetch = async (url) => {
-        requestedHosts.push(new URL(url).host);
-        if (url.startsWith('http://primary.test')) {
+        const value = String(url);
+        requestedHosts.push(new URL(value).host);
+        if (value.startsWith('http://primary.test')) {
             throw new Error('DNS lookup failed');
         }
         return {
+            status: 200,
             ok: true,
+            headers: { get: () => null },
             json: async () => ({ user_info: { auth: 1 } })
         };
     };
@@ -30,7 +33,8 @@ test('Xtream API falls back and remembers the responsive URL', async (t) => {
     const api = new XtreamApi(
         ['http://primary.test', 'http://backup.test'],
         'user',
-        'pass'
+        'pass',
+        { allowPrivate: true }
     );
 
     const result = await api.authenticate();

--- a/test/xtreamApi.test.js
+++ b/test/xtreamApi.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { XtreamApi, normalizeBaseUrls } = require('../server/services/xtreamApi');
+const { getXtreamSeedConfig, seedXtreamSourceFromEnv } = require('../server/services/sourceSeeder');
+
+test('normalizeBaseUrls removes blanks, trailing slashes and duplicates', () => {
+    assert.deepEqual(
+        normalizeBaseUrls('http://primary.test/', ['http://backup.test///', '', 'http://primary.test']),
+        ['http://primary.test', 'http://backup.test']
+    );
+});
+
+test('Xtream API falls back and remembers the responsive URL', async (t) => {
+    const originalFetch = global.fetch;
+    t.after(() => { global.fetch = originalFetch; });
+
+    const requestedHosts = [];
+    global.fetch = async (url) => {
+        requestedHosts.push(new URL(url).host);
+        if (url.startsWith('http://primary.test')) {
+            throw new Error('DNS lookup failed');
+        }
+        return {
+            ok: true,
+            json: async () => ({ user_info: { auth: 1 } })
+        };
+    };
+
+    const api = new XtreamApi(
+        ['http://primary.test', 'http://backup.test'],
+        'user',
+        'pass'
+    );
+
+    const result = await api.authenticate();
+
+    assert.equal(result.user_info.auth, 1);
+    assert.equal(api.baseUrl, 'http://backup.test');
+    assert.deepEqual(requestedHosts, ['primary.test', 'backup.test']);
+    assert.match(api.buildStreamUrl('123', 'live', 'm3u8'), /^http:\/\/backup\.test\/live\//);
+});
+
+test('Xtream seed parses fallback DNS values without exposing credentials in code', () => {
+    const config = getXtreamSeedConfig({
+        SEED_XTREAM_URL: 'http://primary.test/',
+        SEED_XTREAM_FALLBACK_URLS: 'http://backup-a.test,http://backup-b.test',
+        SEED_XTREAM_USERNAME: 'local-user',
+        SEED_XTREAM_PASSWORD: 'local-password'
+    });
+
+    assert.equal(config.url, 'http://primary.test');
+    assert.deepEqual(config.fallbackUrls, ['http://backup-a.test', 'http://backup-b.test']);
+});
+
+test('Xtream seed does not overwrite an existing source', async () => {
+    let createCalls = 0;
+    const sourceStore = {
+        getAll: async () => [{ id: 1, type: 'xtream' }],
+        create: async () => { createCalls += 1; }
+    };
+    const env = {
+        SEED_XTREAM_URL: 'http://primary.test',
+        SEED_XTREAM_USERNAME: 'local-user',
+        SEED_XTREAM_PASSWORD: 'local-password'
+    };
+
+    const result = await seedXtreamSourceFromEnv(env, sourceStore);
+
+    assert.equal(result.reason, 'already-exists');
+    assert.equal(createCalls, 0);
+});


### PR DESCRIPTION
## Summary

- add automatic Xtream DNS failover for API, EPG, sync, and playback startup
- allow alternative DNS URLs to be managed from the source settings UI
- add an optional environment-based Xtream seed without overwriting UI changes
- add a responsive multi-view page with customizable 1, 2, 3, or 4-screen layouts
- stop hidden players when reducing the layout or leaving multi-view
- keep only one multi-view audio feed active at a time
- document failover, multi-view, connection limits, and seed variables

## Validation

- npm test (4 passing tests)
- JavaScript syntax checks
- git diff --check
- desktop and mobile browser validation
- live HLS playback, channel filtering, layout persistence, and stream cleanup verified

## Security

- local credentials remain in the ignored .env file
- no provider credentials or private DNS values are included in this pull request